### PR TITLE
Plot Helpers

### DIFF
--- a/cellarium/cas/client.py
+++ b/cellarium/cas/client.py
@@ -158,9 +158,9 @@ class CASClient:
                     include_dev_metadata=include_dev_metadata,
                 )
 
-            except exceptions.HTTPError500:
+            except exceptions.HTTPError500 as e:
                 self._print(
-                    f"Error occurred in CAS backend (HTTPError500), "
+                    f"{str(e)}, "
                     f"resubmitting chunk #{chunk_index + 1:2.0f} ({chunk_start_i:5.0f}, {chunk_end_i:5.0f}) to CAS ..."
                 )
                 pass

--- a/cellarium/cas/client.py
+++ b/cellarium/cas/client.py
@@ -293,7 +293,7 @@ class CASClient:
         start = time.time()
         cas_model = self._model_name_obj_map[cas_model_name]
         cas_model_name = cas_model["model_name"]
-        self._print(f"CAS v1.0 (Model ID: {cas_model_name})")
+        self._print(f"Cellarium CAS (Model ID: {cas_model_name})")
         self._print(f"Total number of input cells: {len(adata)}")
         adata = self._validate_and_sanitize_input_data(
             adata=adata,

--- a/cellarium/cas/data_preparation.py
+++ b/cellarium/cas/data_preparation.py
@@ -8,6 +8,13 @@ import scipy.sparse as sp
 from cellarium.cas import exceptions
 
 
+def _get_adata_var_index_or_by_column(adata: anndata.AnnData, var_column_name: str) -> t.List[str]:
+    if var_column_name == "index":
+        return adata.var.index.tolist()
+
+    return adata.var[var_column_name].values.tolist()
+
+
 def validate(
     adata: anndata.AnnData,
     cas_feature_schema_list: t.List,
@@ -22,15 +29,13 @@ def validate(
     :param cas_feature_schema_list: List of features to be validated with
     :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. Default `index`.
     """
-    assert feature_ids_column_name == "index" or feature_ids_column_name in adata.var.columns.values, (
-        "`feature_ids_column_name` should have a value of either 'index' "
-        "or be present as a column in the `adata.var` object."
-    )
+    if feature_ids_column_name != "index" and feature_ids_column_name not in adata.var.columns.values:
+        raise ValueError(
+            "`feature_ids_column_name` should have a value of either 'index' "
+            "or be present as a column in the `adata.var` object."
+        )
 
-    if feature_ids_column_name == "index":
-        adata_feature_schema_list = adata.var.index.tolist()
-    else:
-        adata_feature_schema_list = adata.var[feature_ids_column_name].values.tolist()
+    adata_feature_schema_list = _get_adata_var_index_or_by_column(adata=adata, var_column_name=feature_ids_column_name)
 
     cas_feature_schema_set = set(cas_feature_schema_list)
     adata_feature_schema_set = set(adata_feature_schema_list)
@@ -49,6 +54,7 @@ def sanitize(
     cas_feature_schema_list: t.List[str],
     count_matrix_name: str,
     feature_ids_column_name: str,
+    feature_names_column_name: t.Optional[str] = None,
 ) -> anndata.AnnData:
     """
     Cellarium CAS sanitizing script. Returns a new `anndata.AnnData` instance, based on the feature expression
@@ -58,20 +64,26 @@ def sanitize(
     :param cas_feature_schema_list: List of Ensembl feature ids to rely on.
     :param count_matrix_name: Where to obtain a feature expression count matrix from. Choice of: 'X', 'raw.X'
     :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. Default `index`.
+    :param feature_names_column_name: Column name where to obtain feature names. If not provided, no feature names
+        should be mapped |br|
+    `Default`: ``None``
     :return: `anndata.AnnData` instance that is ready to use with CAS
     """
-    assert feature_ids_column_name == "index" or feature_ids_column_name in adata.var.columns.values, (
-        "`feature_ids_column_name` should have a value of either 'index' "
-        "or be present as a column in the `adata.var` object."
-    )
-    assert (
-        count_matrix_name == "X" or count_matrix_name == "raw.X"
-    ), "`count_matrix_name` should have a value of either 'X' or 'raw.X'."
+    if feature_ids_column_name != "index" and feature_ids_column_name not in adata.var.columns.values:
+        raise ValueError(
+            "`feature_ids_column_name` should have a value of either 'index' "
+            "or be present as a column in the `adata.var` object."
+        )
+    if feature_names_column_name not in {"index", None} and feature_names_column_name not in adata.var.columns.values:
+        raise ValueError(
+            "`feature_ids_name_column_name` should have a value of either 'index' "
+            "or be present as a column in the `adata.var` object."
+        )
+    if count_matrix_name not in {"X", "raw.X"}:
+        raise ValueError("`count_matrix_name` should have a value of either 'X' or 'raw.X'.")
 
-    if feature_ids_column_name == "index":
-        adata_feature_schema_list = adata.var.index.tolist()
-    else:
-        adata_feature_schema_list = adata.var[feature_ids_column_name].values.tolist()
+    adata_feature_schema_list = _get_adata_var_index_or_by_column(adata=adata, var_column_name=feature_ids_column_name)
+
     cas_feature_schema_set = set(cas_feature_schema_list)
     adata_feature_schema_set = set(adata_feature_schema_list)
     feature_id_intersection = adata_feature_schema_set.intersection(cas_feature_schema_set)
@@ -99,9 +111,24 @@ def sanitize(
     obs = adata.obs.copy()
     obs.index = pd.Index([str(x) for x in np.arange(adata.shape[0])])
 
+    var_df_data = {}
+    if feature_names_column_name is not None:
+        adata_feature_name_list = _get_adata_var_index_or_by_column(
+            adata=adata, var_column_name=feature_names_column_name
+        )
+        gene_id_to_gene_symbol_map = {
+            gene_id: gene_symbol for gene_symbol, gene_id in zip(adata_feature_name_list, adata_feature_schema_list)
+        }
+        cas_feature_name_list = [
+            gene_id_to_gene_symbol_map[gene_id] if gene_id in gene_id_to_gene_symbol_map else "N/A"
+            for gene_id in cas_feature_schema_list
+        ]
+        var_df_data["feature_name"] = cas_feature_name_list
+
+    var_df = pd.DataFrame(index=cas_feature_schema_list, data=var_df_data)
     return anndata.AnnData(
         result_matrix.tocsr(),
         obs=obs,
         obsm=adata.obsm,
-        var=pd.DataFrame(index=cas_feature_schema_list),
+        var=var_df,
     )

--- a/cellarium/cas/exceptions.py
+++ b/cellarium/cas/exceptions.py
@@ -4,26 +4,24 @@ from dataclasses import dataclass
 class CASBaseError(Exception):
     """Base class for all CAS exceptions"""
 
-    pass
-
 
 class CASClientError(CASBaseError):
     pass
 
 
-class HTTPBaseError(CASBaseError):
+class HTTPError(CASBaseError):
     pass
 
 
-class HTTPError500(HTTPBaseError):
+class HTTPError500(HTTPError):
     pass
 
 
-class HTTPError403(HTTPBaseError):
+class HTTPError403(HTTPError):
     pass
 
 
-class HTTPError401(HTTPBaseError):
+class HTTPError401(HTTPError):
     pass
 
 

--- a/cellarium/cas/scanpy_utils.py
+++ b/cellarium/cas/scanpy_utils.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import typing as t
+from collections import defaultdict
+from operator import itemgetter
+
+import numpy as np
+from tqdm.notebook import tqdm
+
+if t.TYPE_CHECKING:
+    import anndata
+
+
+ALLOWED_WNN_STRATEGIES = {"connectivities"}
+
+
+def reduce_cas_query_result_by_majority_vote(
+    adata: "anndata.AnnData",
+    cas_query_res: dict,
+    output_cell_type_key: str = "cas_cell_type",
+    output_cell_type_confidence_score_key: str = "cas_cell_type_confidence_score",
+):
+    majority_vote_cell_type_list = []
+    majority_vote_confidence_score_list = []
+    for single_cell_query in cas_query_res:
+        total_cell_count = 0
+        best_cell_count = -1
+        best_cell_type = None
+        for match in single_cell_query["matches"]:
+            total_cell_count += match["cell_count"]
+            if match["cell_count"] > best_cell_count:
+                best_cell_count = match["cell_count"]
+                best_cell_type = match["cell_type"]
+        majority_vote_cell_type_list.append(best_cell_type)
+        majority_vote_confidence_score_list.append(best_cell_count / total_cell_count)
+
+    adata.obs[output_cell_type_key] = majority_vote_cell_type_list
+    adata.obs[output_cell_type_confidence_score_key] = majority_vote_confidence_score_list
+
+
+def reduce_cas_query_result_by_min_distance(
+    adata: "anndata.AnnData",
+    cas_query_res: dict,
+    output_cell_type_key: str = "cas_cell_type",
+    output_cell_type_min_distance_key: str = "cas_cell_type_min_distance",
+):
+    min_distance_cell_type_list = []
+    min_distance_list = []
+    for single_cell_query in cas_query_res:
+        min_distance = np.inf
+        best_cell_type = None
+        for match in single_cell_query["matches"]:
+            if match["min_distance"] < min_distance:
+                min_distance = match["min_distance"]
+                best_cell_type = match["cell_type"]
+        min_distance_cell_type_list.append(best_cell_type)
+        min_distance_list.append(min_distance)
+
+    adata.obs[output_cell_type_key] = min_distance_cell_type_list
+    adata.obs[output_cell_type_min_distance_key] = min_distance_list
+
+
+def reduce_cas_query_result_by_majority_vote_per_cluster(
+    adata: anndata.AnnData,
+    cas_query_res: dict,
+    cluster_key: str = "leiden",
+    output_cell_type_key: str = "cas_per_cluster_cell_type",
+    output_cell_type_confidence_score_key: str = "cas_per_cluster_cell_type_confidence_score",
+    ignore_set: set = set(),
+) -> dict:
+    if len(adata) != len(cas_query_res):
+        raise ValueError("Lengths of `cas_query_res` and `adata` should be the same")
+    if cluster_key not in adata.obs:
+        raise ValueError("`cluster_key` does not correspond list of column names from `adata.obs`")
+
+    output_cell_type_list = [None] * adata.shape[0]
+    output_cell_type_confidence_score_list = [None] * adata.shape[0]
+    cluster_detailed_info_dict = dict()
+
+    for cluster_id in adata.obs[cluster_key].values.categories:
+        # obtain cell indices belonging to cluster_id
+        cluster_cell_indices = np.where(adata.obs[cluster_key] == cluster_id)[0]
+
+        if len(cluster_cell_indices) == 0:
+            raise ValueError(f"No cells found belonging to cluster_id {cluster_id}")
+
+        # summarize the hits of all cells
+        cluster_query = defaultdict(int)
+        for cell_index in cluster_cell_indices:
+            single_cell_query = cas_query_res[cell_index]
+            for match in single_cell_query["matches"]:
+                if match["cell_type"] in ignore_set:
+                    continue
+                cluster_query[match["cell_type"]] += match["cell_count"]
+
+        # identify the best cell type for the cluster
+        total_cell_count = sum(cluster_query.values())
+        sorted_hits_and_freqs = sorted(
+            [(cell_type, count / total_cell_count) for cell_type, count in cluster_query.items()],
+            key=itemgetter(1),
+            reverse=True,
+        )
+        best_cell_type = sorted_hits_and_freqs[0][0]
+        best_cell_type_confidence_score = sorted_hits_and_freqs[0][1]
+
+        # bookkeeping
+        cluster_detailed_info_dict[cluster_id] = sorted_hits_and_freqs
+        for cell_index in cluster_cell_indices:
+            output_cell_type_list[cell_index] = best_cell_type
+            output_cell_type_confidence_score_list[cell_index] = best_cell_type_confidence_score
+
+    adata.obs[output_cell_type_key] = output_cell_type_list
+    adata.obs[output_cell_type_confidence_score_key] = output_cell_type_confidence_score_list
+
+    return cluster_detailed_info_dict
+
+
+def _get_weights_via_fuzzy_simplicial_sets(
+    i: int, adata: anndata.AnnData, n_neighbors: int, self_connectivity: float, connectivities_key: str
+) -> tuple:
+    connectivity_values = adata.obsp[connectivities_key][i].data
+    connectivity_indices = adata.obsp[connectivities_key][i].indices
+
+    # append self
+    connectivity_values = np.append(connectivity_values, self_connectivity)
+    connectivity_indices = np.append(connectivity_indices, i)
+
+    # convert to weights
+    _order = np.argsort(connectivity_values)[::-1][:n_neighbors]
+    sorted_connectivity_values = connectivity_values[_order]
+    sorted_connectivity_indices = connectivity_indices[_order]
+    weights = sorted_connectivity_values / np.sum(sorted_connectivity_values)
+    return sorted_connectivity_indices, weights
+
+
+def _get_cell_type_probs(single_cell_query: t.Dict, all_cell_types: t.List, cell_type_to_idx_map: t.Dict) -> np.ndarray:
+    probs = np.zeros((len(all_cell_types),))
+    for match in single_cell_query["matches"]:
+        probs[cell_type_to_idx_map[match["cell_type"]]] += match["cell_count"]
+    return probs / np.sum(probs)
+
+
+def reduce_cas_query_result_by_wnn(
+    adata: anndata.AnnData,
+    cas_query_res: dict,
+    n_neighbors: int = 10,
+    wnn_strategy: str = "connectivities",
+    connectivities_key: str = "connectivities",
+    self_connectivity: float = 1.0,
+    min_n_cells_per_type: int = 10,
+    output_unreliable_type: str = "Unknown or Unconfident",
+    output_cell_type_key: str = "cas_cell_type",
+    output_cell_type_confidence_score_key: str = "cas_cell_type_confidence_score",
+):
+    if wnn_strategy not in ALLOWED_WNN_STRATEGIES:
+        raise ValueError(
+            f"`wnn_strategy` should be one of {', '.join(ALLOWED_WNN_STRATEGIES)}, got {wnn_strategy} instead"
+        )
+    if n_neighbors > adata.uns["neighbors"]["params"]["n_neighbors"]:
+        raise ValueError(
+            "`n_neighbors` should be less than or equal to `adata.uns['neighbors']['params']['n_neighbors']`"
+        )
+    if len(adata) != len(cas_query_res):
+        raise ValueError("Lengths of `cas_query_res` and `adata` should be the same")
+
+    all_cell_types = []
+    for single_cell_query in cas_query_res:
+        for match in single_cell_query["matches"]:
+            all_cell_types.append(match["cell_type"])
+    all_cell_types = list(set(all_cell_types))
+    cell_type_to_idx_map = {cell_type: idx for idx, cell_type in enumerate(all_cell_types)}
+
+    cell_type_probs_list = []
+    majority_vote_cell_type_list = []
+    majority_vote_confidence_score_list = []
+
+    n_cells = len(cas_query_res)
+    for i in tqdm(range(n_cells)):
+        neighbor_indices, neighbor_weights = _get_weights_via_fuzzy_simplicial_sets(
+            i, adata, n_neighbors, self_connectivity, connectivities_key=connectivities_key
+        )
+        if not np.isclose(np.sum(neighbor_weights), 1.0):
+            raise ValueError("Sum of Neighbor weights is not close to 1")
+
+        cell_type_probs = np.zeros((len(all_cell_types),))
+        for j, weight in zip(neighbor_indices, neighbor_weights):
+            cell_type_probs += weight * _get_cell_type_probs(cas_query_res[j], all_cell_types, cell_type_to_idx_map)
+
+        best_cell_type_idx = np.argmax(cell_type_probs)
+        best_cell_type = all_cell_types[best_cell_type_idx]
+        best_cell_type_prob = cell_type_probs[best_cell_type_idx]
+
+        cell_type_probs_list.append(cell_type_probs)
+        majority_vote_cell_type_list.append(best_cell_type)
+        majority_vote_confidence_score_list.append(best_cell_type_prob)
+
+    all_cell_types = set(majority_vote_cell_type_list)
+    update_map = dict()
+    for cell_type in all_cell_types:
+        n_counts = sum([_cell_type == cell_type for _cell_type in majority_vote_cell_type_list])
+        if n_counts < min_n_cells_per_type:
+            update_map[cell_type] = output_unreliable_type
+        else:
+            update_map[cell_type] = cell_type
+    majority_vote_cell_type_list = list(map(update_map.get, majority_vote_cell_type_list))
+
+    adata.obs[output_cell_type_key] = majority_vote_cell_type_list
+    adata.obs[output_cell_type_confidence_score_key] = majority_vote_confidence_score_list
+
+    return cell_type_to_idx_map, cell_type_probs_list
+
+
+def hex_to_rgb(value: str) -> np.ndarray:
+    value = value.lstrip("#")
+    lv = len(value)
+    return np.asarray(tuple(float(int(value[i : i + lv // 3], 16)) for i in range(0, lv, lv // 3)))
+
+
+def rgb_to_tuple(value: np.ndarray) -> tuple:
+    return int(value[0]), int(value[1]), int(value[2])
+
+
+# def rgb_to_hex(rgb: t.Tuple[int, int, int]) -> str:
+def rgb_to_hex(r: int, g: int, b: int) -> str:
+    return "#%02x%02x%02x" % (r, g, b)
+
+
+def get_interpolated_cell_type_colors(
+    adata, cell_type_to_idx_map, cell_type_probs_list, na_cell_type_key="Unknown or Unconfident"
+) -> np.ndarray:
+    idx_to_cell_type_map = {idx: cell_type for cell_type, idx in cell_type_to_idx_map.items()}
+    all_cell_types = list(map(idx_to_cell_type_map.get, range(len(cell_type_to_idx_map))))
+    plot_cell_type_colors = adata.uns["cas_cell_type_colors"]
+    plot_cell_types = list(adata.obs["cas_cell_type"].values.categories)
+    plot_cell_types_to_idx_map = {cell_type: idx for idx, cell_type in enumerate(plot_cell_types)}
+
+    cell_type_probs_nk = np.asarray(cell_type_probs_list)
+    cell_type_map_kq = np.zeros((len(all_cell_types), len(plot_cell_types)))
+    na_index = plot_cell_types.index(na_cell_type_key)
+    plot_cell_type_colors[na_index] = rgb_to_hex(r=255, g=255, b=255)
+    for k, input_cell_type in enumerate(all_cell_types):
+        if input_cell_type in plot_cell_types_to_idx_map:
+            q = plot_cell_types_to_idx_map[input_cell_type]
+        else:
+            q = na_index
+        cell_type_map_kq[k, q] += 1
+
+    plot_colors_q3 = np.asarray(list(hex_to_rgb(hex_color) for hex_color in plot_cell_type_colors))
+    cell_colors_n3 = (cell_type_probs_nk @ cell_type_map_kq @ plot_colors_q3) / 255
+
+    return np.clip(cell_colors_n3, 0.0, 1.0)

--- a/cellarium/cas/service.py
+++ b/cellarium/cas/service.py
@@ -11,6 +11,8 @@ from cellarium.cas import endpoints, exceptions
 
 nest_asyncio.apply()
 
+AIOHTTP_TIMEOUT_SECONDS = 1200
+
 
 class _BaseService:
     BACKEND_URL: str
@@ -127,8 +129,10 @@ class _BaseService:
 
         ssl_context = ssl.create_default_context(cafile=certifi.where())
         conn = aiohttp.TCPConnector(ssl=ssl_context)
+        # Define your custom timeout
+        timeout = aiohttp.ClientTimeout(total=AIOHTTP_TIMEOUT_SECONDS)
 
-        async with aiohttp.ClientSession(connector=conn) as session:
+        async with aiohttp.ClientSession(connector=conn, timeout=timeout) as session:
             async with session.post(url, data=form_data, headers=_headers) as response:
                 status_code = response.status
                 if status_code < 200 or status_code >= 300:

--- a/cellarium/cas/service.py
+++ b/cellarium/cas/service.py
@@ -97,7 +97,7 @@ class CASAPIService(_BaseService):
     Class with all the API methods of Cellarium Cloud CAS infrastructure.
     """
 
-    BACKEND_URL = "https://cas-api-june-release-vi7nxpvk7a-uc.a.run.app"
+    BACKEND_URL = "https://cas-api-1-2-dev-vi7nxpvk7a-uc.a.run.app"
 
     def validate_token(self) -> None:
         """
@@ -152,7 +152,7 @@ class CASAPIService(_BaseService):
         return self.get_json(endpoint=endpoints.LIST_MODELS)
 
     async def async_annotate_anndata_chunk(
-        self, adata_file_bytes: t.ByteString, number_of_cells: int, model_name: str
+        self, adata_file_bytes: t.ByteString, number_of_cells: int, model_name: str, include_dev_metadata: bool
     ) -> t.List[t.Dict[str, t.Any]]:
         """
         Request Cellarium Cloud infrastructure to annotate an input anndata file
@@ -162,7 +162,12 @@ class CASAPIService(_BaseService):
         :param adata_file_bytes: Validated anndata file
         :param number_of_cells: Number of cells being processed in this dataset
         :param model_name: Name of the model to use.
+        :param include_dev_metadata: Whether to include dev metadata in the response.
         :return: A list of dictionaries with annotations.
         """
-        request_data = {"number_of_cells": str(number_of_cells), "model_name": model_name}
+        request_data = {
+            "number_of_cells": str(number_of_cells),
+            "model_name": model_name,
+            "include_dev_metadata": str(include_dev_metadata),
+        }
         return await self.async_post(endpoints.ANNOTATE, file=adata_file_bytes, data=request_data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ include = ["cellarium.*"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements/base.txt"]}
-optional-dependencies = {docs = { file = ["requirements/docs.txt"] }, test = { file = ["requirements/test.txt"]}}
+optional-dependencies = {docs = { file = ["requirements/docs.txt"] }, test = { file = ["requirements/test.txt"]}, scanpy = { file = ["requirements/scanpy.txt"]}}
 readme = {file = ["README.md"]}
 
 [project.urls]

--- a/requirements/scanpy.txt
+++ b/requirements/scanpy.txt
@@ -1,0 +1,2 @@
+scanpy[leiden]>=1.9.0,<1.9.6
+tqdm~=4.66


### PR DESCRIPTION
This branch is based on `mb_cli_helper_scripts` branch. It is squashed, formatted with tox and restructured according to the latest project structure. 

This PR establishes utils and changes a protection rule of the method of data validation and sanitization. Since now, CASClient can be used just to sanitize an input adata file according to the schema for a particular model.