### PR TITLE
Fix: #55 Fix total_mrna_umis for raw.X

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,18 @@ All notable changes to Cellarium CAS client will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+1.4.3 - 2024-03-18
+------------------
+
+Added
+~~~~~
+- Fix total mrna umis for normalized data
+
+Changed
+~~~~~~~
+- Handle different matrix types in the data preparation callbacks
+- Update unit tests for the data preparation callbacks
+
 1.4.2 - 2024-03-12
 ------------------
 

--- a/cellarium/cas/client.py
+++ b/cellarium/cas/client.py
@@ -9,7 +9,7 @@ import warnings
 
 import anndata
 
-from cellarium.cas import _io, data_preparation, exceptions, service, settings
+from cellarium.cas import _io, constants, data_preparation, exceptions, service, settings
 
 CHUNK_SIZE_ANNOTATE_DEFAULT = 1000
 CHUNK_SIZE_SEARCH_DEFAULT = 500
@@ -74,7 +74,7 @@ class CASClient:
         self,
         adata: anndata.AnnData,
         cas_model_name: str,
-        count_matrix_name: str,
+        count_matrix_name: constants.CountMatrixInput,
         feature_ids_column_name: str,
         feature_names_column_name: t.Optional[str] = None,
     ) -> anndata.AnnData:
@@ -139,7 +139,7 @@ class CASClient:
             return data_preparation.sanitize(
                 adata=adata,
                 cas_feature_schema_list=cas_feature_schema_list,
-                count_matrix_name=count_matrix_name,
+                count_matrix_input=count_matrix_name,
                 feature_ids_column_name=feature_ids_column_name,
                 feature_names_column_name=feature_names_column_name,
             )
@@ -335,7 +335,7 @@ class CASClient:
         self,
         adata: anndata.AnnData,
         cas_model_name: str = "default",
-        count_matrix_name: str = "X",
+        count_matrix_input: constants.CountMatrixInput = constants.CountMatrixInput.X,
         feature_ids_column_name: str = "index",
         feature_names_column_name: t.Optional[str] = None,
     ) -> anndata.AnnData:
@@ -347,10 +347,9 @@ class CASClient:
             `Allowed Values:` Model name from the :attr:`allowed_models_list` list or ``"default"``
             keyword, which refers to the default selected model in the Cellarium backend. |br|
             `Default:` ``"default"``
-        :param count_matrix_name:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values:` Choice of either ``"X"``  or ``"raw.X"`` in order to use ``adata.X`` or ``adata.raw.X``
-            |br|
-            `Default:` ``"X"``
+        :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
+            `Allowed Values: Choices from enum :class:`cellarium.cas.constants.CountMatrixInput` |br|
+            `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
             column. |br|
@@ -378,7 +377,7 @@ class CASClient:
         return self.validate_and_sanitize_input_data(
             adata=adata,
             cas_model_name=cas_model_name,
-            count_matrix_name=count_matrix_name,
+            count_matrix_name=count_matrix_input,
             feature_ids_column_name=feature_ids_column_name,
             feature_names_column_name=feature_names_column_name,
         )
@@ -388,7 +387,7 @@ class CASClient:
         adata: "anndata.AnnData",
         chunk_size=CHUNK_SIZE_ANNOTATE_DEFAULT,
         cas_model_name: str = "default",
-        count_matrix_name: str = "X",
+        count_matrix_input: constants.CountMatrixInput = constants.CountMatrixInput.X,
         feature_ids_column_name: str = "index",
         feature_names_column_name: t.Optional[str] = None,
         include_dev_metadata: bool = False,
@@ -404,10 +403,9 @@ class CASClient:
             `Allowed Values:` Model name from the :attr:`allowed_models_list` list or ``"default"``
             keyword, which refers to the default selected model in the Cellarium backend. |br|
             `Default:` ``"default"``
-        :param count_matrix_name:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values:` Choice of either ``"X"``  or ``"raw.X"`` in order to use ``adata.X`` or ``adata.raw.X``
-            |br|
-            `Default:` ``"X"``
+        :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
+            `Allowed Values: Choices from enum :class:`cellarium.cas.constants.CountMatrixInput` |br|
+            `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
             column. |br|
@@ -427,7 +425,7 @@ class CASClient:
         adata = self.__prepare_input_for_sharded_request(
             adata=adata,
             cas_model_name=cas_model_name,
-            count_matrix_name=count_matrix_name,
+            count_matrix_input=count_matrix_input,
             feature_ids_column_name=feature_ids_column_name,
             feature_names_column_name=feature_names_column_name,
         )
@@ -450,7 +448,7 @@ class CASClient:
         filepath: str,
         chunk_size=CHUNK_SIZE_ANNOTATE_DEFAULT,
         cas_model_name: str = "default",
-        count_matrix_name: str = "X",
+        count_matrix_input: constants.CountMatrixInput = constants.CountMatrixInput.X,
         feature_ids_column_name: str = "index",
         feature_names_column_name: t.Optional[str] = None,
         include_dev_metadata: bool = False,
@@ -464,10 +462,9 @@ class CASClient:
             `Allowed Values:` Model name from the :attr:`allowed_models_list` list or ``"default"``
             keyword, which refers to the default selected model in the Cellarium backend. |br|
             `Default:` ``"default"``
-        :param count_matrix_name:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values:` Choice of either ``"X"``  or ``"raw.X"`` in order to use ``adata.X`` or ``adata.raw.X``
-            |br|
-            `Default:` ``"X"``
+        :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
+            `Allowed Values: Choices from enum :class:`cellarium.cas.constants.CountMatrixInput` |br|
+            `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
             column. |br|
@@ -489,7 +486,7 @@ class CASClient:
             adata=adata,
             chunk_size=chunk_size,
             cas_model_name=cas_model_name,
-            count_matrix_name=count_matrix_name,
+            count_matrix_input=count_matrix_input,
             feature_ids_column_name=feature_ids_column_name,
             feature_names_column_name=feature_names_column_name,
             include_dev_metadata=include_dev_metadata,
@@ -500,7 +497,7 @@ class CASClient:
         filepath: str,
         chunk_size: int = CHUNK_SIZE_ANNOTATE_DEFAULT,
         cas_model_name: str = "default",
-        count_matrix_name: str = "X",
+        count_matrix_input: constants.CountMatrixInput = constants.CountMatrixInput.X,
         feature_ids_column_name: str = "index",
         feature_names_column_name: t.Optional[str] = None,
         include_dev_metadata: bool = False,
@@ -514,10 +511,9 @@ class CASClient:
             `Allowed Values:` Model name from the :attr:`allowed_models_list` list or ``"default"``
             keyword, which refers to the default selected model in the Cellarium backend. |br|
             `Default:` ``"default"``
-        :param count_matrix_name:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values:` Choice of either ``"X"``  or ``"raw.X"`` in order to use ``adata.X`` or ``adata.raw.X``
-            |br|
-            `Default:` ``"X"``
+        :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
+            `Allowed Values: Choices from enum :class:`cellarium.cas.constants.CountMatrixInput` |br|
+            `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
             column. |br|
@@ -536,7 +532,7 @@ class CASClient:
             adata=adata,
             chunk_size=chunk_size,
             cas_model_name=cas_model_name,
-            count_matrix_name=count_matrix_name,
+            count_matrix_input=count_matrix_input,
             feature_ids_column_name=feature_ids_column_name,
             feature_names_column_name=feature_names_column_name,
             include_dev_metadata=include_dev_metadata,
@@ -547,7 +543,7 @@ class CASClient:
         adata: anndata.AnnData,
         chunk_size=CHUNK_SIZE_SEARCH_DEFAULT,
         cas_model_name: str = "default",
-        count_matrix_name: str = "X",
+        count_matrix_input: constants.CountMatrixInput = constants.CountMatrixInput.X,
         feature_ids_column_name: str = "index",
         feature_names_column_name: t.Optional[str] = None,
     ) -> t.List[t.Dict[str, t.Any]]:
@@ -563,10 +559,9 @@ class CASClient:
             `Allowed Values:` Model name from the :attr:`allowed_models_list` list or ``"default"``
             keyword, which refers to the default selected model in the Cellarium backend. |br|
             `Default:` ``"default"``
-        :param count_matrix_name:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values:` Choice of either ``"X"``  or ``"raw.X"`` in order to use ``adata.X`` or ``adata.raw.X``
-            |br|
-            `Default:` ``"X"``
+        :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
+            `Allowed Values: Choices from enum :class:`cellarium.cas.constants.CountMatrixInput` |br|
+            `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
             column. |br|
@@ -588,7 +583,7 @@ class CASClient:
         adata = self.__prepare_input_for_sharded_request(
             adata=adata,
             cas_model_name=cas_model_name,
-            count_matrix_name=count_matrix_name,
+            count_matrix_input=count_matrix_input,
             feature_ids_column_name=feature_ids_column_name,
             feature_names_column_name=feature_names_column_name,
         )
@@ -608,7 +603,7 @@ class CASClient:
         filepath: str,
         chunk_size: int = CHUNK_SIZE_SEARCH_DEFAULT,
         cas_model_name: str = "default",
-        count_matrix_name: str = "X",
+        count_matrix_input: constants.CountMatrixInput = constants.CountMatrixInput.X,
         feature_ids_column_name: str = "index",
         feature_names_column_name: t.Optional[str] = None,
     ) -> t.List[t.Dict[str, t.Any]]:
@@ -621,10 +616,9 @@ class CASClient:
             `Allowed Values:` Model name from the :attr:`allowed_models_list` list or ``"default"``
             keyword, which refers to the default selected model in the Cellarium backend. |br|
             `Default:` ``"default"``
-        :param count_matrix_name:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values:` Choice of either ``"X"``  or ``"raw.X"`` in order to use ``adata.X`` or ``adata.raw.X``
-            |br|
-            `Default:` ``"X"``
+        :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
+            `Allowed Values: Choices from enum :class:`cellarium.cas.constants.CountMatrixInput` |br|
+            `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
             column. |br|
@@ -643,7 +637,7 @@ class CASClient:
             adata=adata,
             chunk_size=chunk_size,
             cas_model_name=cas_model_name,
-            count_matrix_name=count_matrix_name,
+            count_matrix_input=count_matrix_input,
             feature_ids_column_name=feature_ids_column_name,
             feature_names_column_name=feature_names_column_name,
         )
@@ -652,8 +646,8 @@ class CASClient:
         self, cell_ids: t.List[int], model_name: str, metadata_feature_names: t.List[str] = None
     ) -> t.List[t.Dict[str, t.Any]]:
         """
-        Query cells by their ids from a single anndata file with Cellarium CAS. Input file should be validated and sanitized
-        according to the model schema.
+        Query cells by their ids from a single anndata file with Cellarium CAS. Input file should be validated and
+        sanitized according to the model schema.
 
         :param cell_ids: List of cell ids to query
         :param model_name: Model name to use for annotation. |br|

--- a/cellarium/cas/constants.py
+++ b/cellarium/cas/constants.py
@@ -1,3 +1,6 @@
+from enum import Enum
+
+
 class HTTP:
     """
     HTTP status codes constants
@@ -21,3 +24,8 @@ class HTTP:
     STATUS_503_SERVICE_UNAVAILABLE = 503
     STATUS_504_GATEWAY_TIMEOUT = 504
     STATUS_511_NETWORK_AUTHENTICATION_REQUIRED = 511
+
+
+class CountMatrixInput(Enum):
+    X: str = "X"
+    RAW_X: str = "raw.X"

--- a/cellarium/cas/data_preparation/callbacks.py
+++ b/cellarium/cas/data_preparation/callbacks.py
@@ -1,21 +1,21 @@
 import typing as t
 
+import anndata
 import numpy as np
 
-if t.TYPE_CHECKING:
-    import anndata
+from cellarium.cas import constants
 
 TOTAL_MRNA_UMIS_COLUMN_NAME = "total_mrna_umis"
 
 
-def calculate_total_mrna_umis(adata: "anndata.AnnData", count_matrix_name: str) -> None:
+def calculate_total_mrna_umis(adata: anndata.AnnData, count_matrix_input: constants.CountMatrixInput) -> None:
     """
     Calculate the total mRNA UMIs (Unique Molecular Identifiers) for each observation in the AnnData object and add them
     as a new column in the ``.obs`` attribute. It is recommended to use this callback before data sanitization to
     calculate all expressed genes.
 
     :param adata: The annotated data matrix from which to calculate the total mRNA UMIs.
-    :param count_matrix_name: Where to obtain a feature expression count matrix from. Choice of: 'X', 'raw.X'
+    :param count_matrix_input: Where to obtain a feature expression count matrix from. Choice of: 'X', 'raw.X'
 
     :return: A new AnnData object with the same data as ``adata`` but with an additional field in ``.obs`` containing
         the total mRNA UMIs for each observation.
@@ -31,28 +31,23 @@ def calculate_total_mrna_umis(adata: "anndata.AnnData", count_matrix_name: str) 
         >>> 'total_mrna_umis' in adata.obs.columns
         True.
     """
-    if count_matrix_name not in {"X", "raw.X"}:
-        raise ValueError("`count_matrix_name` should have a value of either 'X' or 'raw.X'.")
-
-    if count_matrix_name == "raw.X":
-        count_matrix = adata.raw.X
-    else:
-        count_matrix = adata.X
-
+    count_matrix = adata.X if count_matrix_input == constants.CountMatrixInput.X else adata.raw.X
     adata.obs[TOTAL_MRNA_UMIS_COLUMN_NAME] = np.array(count_matrix.sum(axis=1)).flatten()
 
 
-_PRE_SANITIZE_CALLBACKS: t.List[t.Callable[["anndata.AnnData", str], None]] = [calculate_total_mrna_umis]
+_PRE_SANITIZE_CALLBACKS: t.List[t.Callable[[anndata.AnnData, constants.CountMatrixInput], None]] = [
+    calculate_total_mrna_umis,
+]
 
 
-def pre_sanitize_callback(adata: "anndata.AnnData", count_matrix_name: str) -> None:
+def pre_sanitize_callback(adata: anndata.AnnData, count_matrix_input: constants.CountMatrixInput) -> None:
     """
     Apply each necessary callback before data sanitization
 
     :param adata: Input :class:`anndata.AnnData` instance
-    :param count_matrix_name: Where to obtain a feature expression count matrix from. Choice of: 'X', 'raw.X'
+    :param count_matrix_input: Where to obtain a feature expression count matrix from. Choice of: 'X', 'raw.X'
 
     :return: A new :class:`anndata.AnnData` instance after callback modifications
     """
     for callback in _PRE_SANITIZE_CALLBACKS:
-        callback(adata, count_matrix_name)
+        callback(adata, count_matrix_input)

--- a/cellarium/cas/data_preparation/sanitizer.py
+++ b/cellarium/cas/data_preparation/sanitizer.py
@@ -83,7 +83,7 @@ def sanitize(
     if count_matrix_name not in {"X", "raw.X"}:
         raise ValueError("`count_matrix_name` should have a value of either 'X' or 'raw.X'.")
 
-    callbacks.pre_sanitize_callback(adata=adata)
+    callbacks.pre_sanitize_callback(adata=adata, count_matrix_name=count_matrix_name)
 
     adata_feature_schema_list = _get_adata_var_index_or_by_column(adata=adata, var_column_name=feature_ids_column_name)
     original_obs_ids = adata.obs.index.values

--- a/cellarium/cas/data_preparation/sanitizer.py
+++ b/cellarium/cas/data_preparation/sanitizer.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 import scipy.sparse as sp
 
-from cellarium.cas import exceptions
+from cellarium.cas import constants, exceptions
 from cellarium.cas.data_preparation import callbacks
 
 
@@ -53,7 +53,7 @@ def validate(
 def sanitize(
     adata: anndata.AnnData,
     cas_feature_schema_list: t.List[str],
-    count_matrix_name: str,
+    count_matrix_input: constants.CountMatrixInput,
     feature_ids_column_name: str,
     feature_names_column_name: t.Optional[str] = None,
 ) -> anndata.AnnData:
@@ -63,7 +63,7 @@ def sanitize(
 
     :param adata: Instance to sanitize
     :param cas_feature_schema_list: List of Ensembl feature ids to rely on.
-    :param count_matrix_name: Where to obtain a feature expression count matrix from. Choice of: 'X', 'raw.X'
+    :param count_matrix_input: Where to obtain a feature expression count matrix from. Choice of: 'X', 'raw.X'
     :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. Default `index`.
     :param feature_names_column_name: Column name where to obtain feature names. If not provided, no feature names
         should be mapped |br|
@@ -80,10 +80,8 @@ def sanitize(
             "`feature_ids_name_column_name` should have a value of either 'index' "
             "or be present as a column in the `adata.var` object."
         )
-    if count_matrix_name not in {"X", "raw.X"}:
-        raise ValueError("`count_matrix_name` should have a value of either 'X' or 'raw.X'.")
 
-    callbacks.pre_sanitize_callback(adata=adata, count_matrix_name=count_matrix_name)
+    callbacks.pre_sanitize_callback(adata=adata, count_matrix_input=count_matrix_input)
 
     adata_feature_schema_list = _get_adata_var_index_or_by_column(adata=adata, var_column_name=feature_ids_column_name)
     original_obs_ids = adata.obs.index.values
@@ -99,7 +97,7 @@ def sanitize(
 
     n_cells = adata.shape[0]
     n_features = len(cas_feature_schema_list)
-    input_matrix = adata.X if count_matrix_name == "X" else adata.raw.X
+    input_matrix = adata.X if count_matrix_input == constants.CountMatrixInput.X else adata.raw.X
 
     # Translate the columns from one matrix to another, convert to COO format to make this efficient.
     col_trans = np.zeros(n_features, dtype=int)

--- a/tests/unit/test_data_preparation.py
+++ b/tests/unit/test_data_preparation.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 import scipy.sparse as sp
 
-from cellarium.cas import data_preparation, exceptions
+from cellarium.cas import constants, data_preparation, exceptions
 
 np_random_state = np.random.RandomState(0)
 
@@ -259,7 +259,7 @@ class TestdataPreparation(unittest.TestCase):
         adata_new = data_preparation.sanitize(
             adata=adata,
             cas_feature_schema_list=cas_feature_schema_list,
-            count_matrix_name="X",
+            count_matrix_input=constants.CountMatrixInput.X,
             feature_ids_column_name="index",
         )
         intersect_features = list(set(cas_feature_schema_list).intersection(set(adata_feature_schema_list)))

--- a/tests/unit/test_data_preparation_callbacks.py
+++ b/tests/unit/test_data_preparation_callbacks.py
@@ -5,7 +5,7 @@ import pandas as pd
 from cellarium.cas.data_preparation import callbacks
 
 
-def test_calculate_total_mrna_umis():
+def test_calculate_total_mrna_umis_X():
     """
     Test :func:`data_preparation.callbacks.calculate_total_mrna_umis` function.
 
@@ -27,7 +27,46 @@ def test_calculate_total_mrna_umis():
     obs = pd.DataFrame(index=["cell1", "cell2", "cell3"])
     adata = anndata.AnnData(X=X, obs=obs)
 
-    callbacks.calculate_total_mrna_umis(adata)
+    callbacks.calculate_total_mrna_umis(adata, count_matrix_name="X")
+
+    assert (
+        callbacks.TOTAL_MRNA_UMIS_COLUMN_NAME in adata.obs.columns
+    ), f"'{callbacks.TOTAL_MRNA_UMIS_COLUMN_NAME}' column not found in .obs"
+
+    np.testing.assert_array_equal(
+        adata.obs[callbacks.TOTAL_MRNA_UMIS_COLUMN_NAME],
+        [3, 1, 3],
+        err_msg="Total mRNA UMI calculations are incorrect",
+    )
+
+
+def test_calculate_total_mrna_umis_raw_X():
+    """
+    Test :func:`data_preparation.callbacks.calculate_total_mrna_umis` function when X has normalized data
+    and ``count_matrix_name="raw.X"``.
+
+    Assert the function indeed creates a ``"total_mrna_umis"`` obs column, check the values correspond to the sum
+    over the axis in raw count matrix, and insure the input :class:`anndata.AnnData` instance remains unchanged.
+
+    Raises:
+    - AssertionError: If either the output :class:`anndata.AnnData` instance doesn't have correct numbers in
+        ``.obs["total_mrna_umis"]`` or if the input :class:`anndata.AnnData` instance has changed.
+    """
+    X = np.array(
+        [
+            [1, 0, 2],  # Cell 1: total mRNA UMIs = 3
+            [0, 0, 1],  # Cell 2: total mRNA UMIs = 1
+            [2, 1, 0],  # Cell 3: total mRNA UMIs = 3
+        ]
+    )
+
+    obs = pd.DataFrame(index=["cell1", "cell2", "cell3"])
+    adata = anndata.AnnData(X=X, obs=obs)
+    # We need to have a anndata file that has normalized values in `X` and raw values in `raw.X`
+    adata.raw = adata
+    adata.X = 10_000 * adata.X / (adata.X.sum(axis=1) + 0.000001)  # Using Normalize Total for matrix X
+
+    callbacks.calculate_total_mrna_umis(adata, count_matrix_name="raw.X")
 
     assert (
         callbacks.TOTAL_MRNA_UMIS_COLUMN_NAME in adata.obs.columns

--- a/tests/unit/test_data_preparation_callbacks.py
+++ b/tests/unit/test_data_preparation_callbacks.py
@@ -2,6 +2,7 @@ import anndata
 import numpy as np
 import pandas as pd
 
+from cellarium.cas import constants
 from cellarium.cas.data_preparation import callbacks
 
 
@@ -27,7 +28,7 @@ def test_calculate_total_mrna_umis_X():
     obs = pd.DataFrame(index=["cell1", "cell2", "cell3"])
     adata = anndata.AnnData(X=X, obs=obs)
 
-    callbacks.calculate_total_mrna_umis(adata, count_matrix_name="X")
+    callbacks.calculate_total_mrna_umis(adata, count_matrix_input=constants.CountMatrixInput.X)
 
     assert (
         callbacks.TOTAL_MRNA_UMIS_COLUMN_NAME in adata.obs.columns
@@ -62,11 +63,11 @@ def test_calculate_total_mrna_umis_raw_X():
 
     obs = pd.DataFrame(index=["cell1", "cell2", "cell3"])
     adata = anndata.AnnData(X=X, obs=obs)
-    # We need to have a anndata file that has normalized values in `X` and raw values in `raw.X`
+    # We need to have an anndata file that has normalized values in `X` and raw values in `raw.X`
     adata.raw = adata
     adata.X = 10_000 * adata.X / (adata.X.sum(axis=1) + 0.000001)  # Using Normalize Total for matrix X
 
-    callbacks.calculate_total_mrna_umis(adata, count_matrix_name="raw.X")
+    callbacks.calculate_total_mrna_umis(adata, count_matrix_input=constants.CountMatrixInput.RAW_X)
 
     assert (
         callbacks.TOTAL_MRNA_UMIS_COLUMN_NAME in adata.obs.columns


### PR DESCRIPTION
This PR fixes a bug associated with `total_mrna_umis` when dealing with normalized input data. Usually, input adata objects store their raw counts in `adata.raw.X`. In such cases, `total_mrna_umis` must be calculated based on `adata.raw.X` rather than `adata.X`. This PR includes a fix and an adjustment to the unit tests, adding an additional test case for the normalized input adata object.