### PR TITLE
Add host config option to client

### DIFF
--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -11,5 +11,6 @@ jobs:
       - uses: ./.github/actions/unit-tests
         env:
           TEST_API_TOKEN: ${{ secrets.TEST_API_TOKEN }}
+          TEST_API_URL: ${{ secrets.TEST_API_URL }}
         with:
           python-version: ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ cellarium/data/
 .DS_Store
 .pre-commit-config.yaml
 .idea
+
+# IDE
+.vscode/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ To use Cellarium CAS, create a client instance with your API token:
 from cellarium.cas import CASClient
 
 api_token = "a_very_long_string_with_some_symbols"
-cas = CASClient(api_token=api_token)
+cas = CASClient(
+  api_token=api_token,
+  api_url=<optional url to connect to a non-standard CAS server>
+)
 ```
 
 ## Annotation

--- a/cellarium/cas/client.py
+++ b/cellarium/cas/client.py
@@ -40,8 +40,13 @@ class CASClient:
 
         self._print(s)
 
-    def __init__(self, api_token: str, num_attempts_per_chunk: int = settings.NUM_ATTEMPTS_PER_CHUNK_DEFAULT) -> None:
-        self.cas_api_service = service.CASAPIService(api_token=api_token)
+    def __init__(
+        self,
+        api_token: str,
+        api_url: str = settings.CELLARIUM_CLOUD_BACKEND_URL,
+        num_attempts_per_chunk: int = settings.NUM_ATTEMPTS_PER_CHUNK_DEFAULT,
+    ) -> None:
+        self.cas_api_service = service.CASAPIService(api_token=api_token, api_url=api_url)
 
         self._print("Connecting to the Cellarium Cloud backend...")
         self.cas_api_service.validate_token()

--- a/cellarium/cas/exceptions.py
+++ b/cellarium/cas/exceptions.py
@@ -17,6 +17,10 @@ class HTTPError5XX(HTTPError):
     pass
 
 
+class HTTPError404(HTTPError):
+    pass
+
+
 class HTTPError403(HTTPError):
     pass
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
 pytest~=7.3
 coverage~=4.5
 click~=8.0
+mockito>=1.5.0

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -20,15 +20,28 @@ Notes:
 
 """
 
+import os
+
 import pytest
 
 
 def pytest_addoption(parser: pytest.Parser):
-    """Add `test_api_token` option to pytest args"""
-    parser.addoption("--test_api_token", action="store", default="default_token", help="Token for API calls")
+    """Add options to pytest args"""
+    parser.addoption(
+        "--test_api_token", action="store", default=os.getenv("TEST_API_TOKEN"), help="Token for API calls"
+    )
+    parser.addoption(
+        "--test_api_url", action="store", default=os.getenv("TEST_API_URL"), help="URL where CAS is running"
+    )
 
 
 @pytest.fixture
 def test_api_token(request: pytest.FixtureRequest) -> str:
     """Get `test_api_token` from parser's options"""
     return request.config.getoption("--test_api_token")
+
+
+@pytest.fixture
+def test_api_url(request: pytest.FixtureRequest) -> str:
+    """Get `test_api_url` from parser's options"""
+    return request.config.getoption("--test_api_url")

--- a/tests/unit/test_cas.py
+++ b/tests/unit/test_cas.py
@@ -7,6 +7,7 @@ and annotates a test dataset using the default model.
 
 import anndata
 import numpy as np
+import pytest
 
 from cellarium.cas import CASClient
 from tests.unit import constants
@@ -14,13 +15,15 @@ from tests.unit import constants
 np_random_state = np.random.RandomState(0)
 
 
-def test_cell_annotation(test_api_token: str):
+@pytest.mark.skip(reason="Need to fix integration test environment.")
+def test_cell_annotation(test_api_token: str, test_api_url: str):
     """
     Test the cell annotation functionality of the CASClient by reading a sample dataset and using the
     annotate_anndata method. It verifies that the number of annotations matches the original cell count.
 
     Parameters:
     - test_api_token (str): The API token used to authenticate with the CASClient.
+    - test_api_url (str): The API url of the CAS backend that the CASClient connects to.
 
     Raises:
     - AssertionError: If the number of annotations doesn't match the original cell count in the dataset.
@@ -28,7 +31,7 @@ def test_cell_annotation(test_api_token: str):
     Notes:
     - Ensure that TEST_ADATA_PATH is correctly defined and points to a valid dataset file.
     """
-    cas = CASClient(api_token=test_api_token)
+    cas = CASClient(api_token=test_api_token, api_url=test_api_url)
     adata = anndata.read_h5ad(constants.TEST_ADATA_PATH)
     result = cas.annotate_anndata(adata=adata, chunk_size=50)
     assert len(result) == len(adata), "Result length does not correspond to original number of cells"

--- a/tests/unit/test_cas_service.py
+++ b/tests/unit/test_cas_service.py
@@ -1,0 +1,103 @@
+import aiohttp
+import pytest
+import requests
+from mockito import mock, unstub, when
+
+from cellarium.cas import exceptions
+from cellarium.cas.service import CASAPIService
+
+TEST_TOKEN = "test_token"
+TEST_URL = "https://cas-host.io"
+
+
+class TestCasService:
+    def setup_method(self) -> None:
+        self.cas_service = CASAPIService(api_token=TEST_TOKEN, api_url=TEST_URL)
+
+    def teardown_method(self) -> None:
+        unstub()
+
+    def test_validate_token(self):
+        self._mock_response(
+            url=f"{TEST_URL}/api/cellarium-general/validate-token",
+            token=TEST_TOKEN,
+            status_code=200,
+            response_body={"username": "foo", "email": "foo@bar.com"},
+        )
+
+        self.cas_service.validate_token()
+
+    def test_validate_token_invalid(self):
+        self._mock_response(
+            url=f"{TEST_URL}/api/cellarium-general/validate-token",
+            token=TEST_TOKEN,
+            status_code=401,
+            response_body={"detail": "Invalid Token"},
+        )
+
+        with pytest.raises(exceptions.HTTPError401, match="Invalid Token"):
+            self.cas_service.validate_token()
+
+    def test_get_application_info(self):
+        response_body = {"application_version": "1.0.0", "default_feature_schema": "foo"}
+        self._mock_response(
+            url=f"{TEST_URL}/api/cellarium-general/application-info",
+            token=TEST_TOKEN,
+            status_code=200,
+            response_body=response_body,
+        )
+
+        assert self.cas_service.get_application_info() == response_body
+
+    def test_get_feature_schemas(self):
+        response_body = [
+            {"schema_name": "schema1"},
+            {"schema_name": "schema2"},
+        ]
+        self._mock_response(
+            url=f"{TEST_URL}/api/cellarium-general/feature-schemas",
+            token=TEST_TOKEN,
+            status_code=200,
+            response_body=response_body,
+        )
+
+        assert self.cas_service.get_feature_schemas() == ["schema1", "schema2"]
+
+    def test_get_feature_schema_by(self):
+        response_body = ["field1", "field2"]
+        self._mock_response(
+            url=f"{TEST_URL}/api/cellarium-general/feature-schema/schema1",
+            token=TEST_TOKEN,
+            status_code=200,
+            response_body=response_body,
+        )
+
+        assert self.cas_service.get_feature_schema_by(name="schema1") == ["field1", "field2"]
+
+    def test_get_feature_schema_by_not_found(self):
+        self._mock_response(
+            url=f"{TEST_URL}/api/cellarium-general/feature-schema/schema1",
+            token=TEST_TOKEN,
+            status_code=404,
+            response_body={"detail": "Not found"},
+        )
+
+        with pytest.raises(exceptions.HTTPError404, match="Not found"):
+            self.cas_service.get_feature_schema_by(name="schema1")
+
+    def test_get_feature_schema_by_unauthorized(self):
+        self._mock_response(
+            url=f"{TEST_URL}/api/cellarium-general/feature-schema/schema1",
+            token=TEST_TOKEN,
+            status_code=403,
+            response_body={"detail": "Unauthorized"},
+        )
+
+        with pytest.raises(exceptions.HTTPError403, match="Unauthorized"):
+            self.cas_service.get_feature_schema_by(name="schema1")
+
+    def _mock_response(self, url: str, token: str, status_code: int, response_body: dict | list):
+        response = mock(aiohttp.ClientResponse)
+        response.status_code = status_code
+        when(response).json().thenReturn(response_body)
+        when(requests).get(url=url, headers={"Authorization": f"Bearer {token}"}).thenReturn(response)

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps = -rrequirements/test.txt
 passenv =
     TEST_API_TOKEN
 commands =
-    pytest -s tests/unit --test_api_token={env:TEST_API_TOKEN:}
+    pytest -s tests/unit --test_api_token={env:TEST_API_TOKEN:} --test_api_url={env:TEST_API_URL:}
 
 
 [testenv:integration]


### PR DESCRIPTION
Adds a new option to the client and service named `api_url` which allows users to connect to a different host.

This also adds unit tests for the client and disables the `test_cas` integration test