### PR TITLE
CAS-6 Add a feedback request link when actions are run

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to Cellarium CAS client will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+1.4.6 - 2024-06-12
+------------------
+
+Added
+~~~~~
+- Add text requesting feedback at the end of calls with instructions on opting out of feedback requests
+
 1.4.5 - 2024-06-03
 ------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
 include requirements/
 include cellarium/cas/assets/cellarium_cas_tx_pca_002_grch38_2020_a.json
+recursive-include cellarium/cas/resources/ *.html

--- a/cellarium/cas/client.py
+++ b/cellarium/cas/client.py
@@ -3,6 +3,7 @@ import datetime
 import functools
 import math
 import operator
+import pkgutil
 import time
 import typing as t
 import warnings
@@ -18,6 +19,8 @@ CHUNK_SIZE_ANNOTATE_DEFAULT = 1000
 CHUNK_SIZE_SEARCH_DEFAULT = 500
 DEFAULT_PRUNE_THRESHOLD = 0.1
 DEFAULT_WEIGHTING_PREFACTOR = 1.0
+
+FEEDBACK_TEMPLATE = pkgutil.get_data(__name__, "resources/feedback_template.html").decode("utf-8")
 
 
 class CASClient:
@@ -92,24 +95,11 @@ class CASClient:
 
     def _render_feedback_link(self):
         try:
-            if settings.is_interactive_environment and self.should_show_feedback:
+            if settings.is_interactive_environment() and self.should_show_feedback:
                 # only import IPython if we are in an interactive environment
-                from IPython.display import Markdown, display
+                from IPython.display import HTML, display
 
-                display(
-                    Markdown(
-                        f"""
-We're happy that you are using the Cell Annotation Service!
-We'd love to hear about your experience and how we can improve.\n
-[Please click here to provide feedback and increase your weekly quota!]({self.cas_api_service.get_feedback_answer_link()})\n
-If you'd like to opt out, you can run the following command in a cell:\n
-```
-[cas client].feedback_opt_out()
-```
-where `[cas client]` is the name of the CAS client instance.
-"""
-                    )
-                )
+                display(HTML(FEEDBACK_TEMPLATE.format(link=self.cas_api_service.get_feedback_answer_link())))
         except ModuleNotFoundError:
             pass
 

--- a/cellarium/cas/client.py
+++ b/cellarium/cas/client.py
@@ -101,7 +101,7 @@ class CASClient:
                         f"""
 We're happy that you are using the Cell Annotation Service!
 We'd love to hear about your experience and how we can improve.\n
-[Please click here to provide feedback and get extra quota!]({self.cas_api_service.get_feedback_answer_link()})\n
+[Please click here to provide feedback and increase your weekly quota!]({self.cas_api_service.get_feedback_answer_link()})\n
 If you'd like to opt out, you can run the following command in a cell:\n
 ```
 [cas client].feedback_opt_out()
@@ -116,7 +116,7 @@ where `[cas client]` is the name of the CAS client instance.
     def feedback_opt_out(self):
         self.should_show_feedback = False
         self.user_info = self.cas_api_service.feedback_opt_out()
-        self._print("Feedback opt-out successful")
+        self._print("Successfully opted out. You will no longer receive requests to provide feedback.")
 
     def validate_and_sanitize_input_data(
         self,

--- a/cellarium/cas/constants.py
+++ b/cellarium/cas/constants.py
@@ -29,3 +29,12 @@ class HTTP:
 class CountMatrixInput(Enum):
     X: str = "X"
     RAW_X: str = "raw.X"
+
+
+class Headers:
+    # The authorization header.
+    authorization = "Authorization"
+    # The client session id that is used to track a user's CAS client session.
+    client_session_id = "x-client-session-id"
+    # The client action id that is used to track a user's logical action that may span multiple requests.
+    client_action_id = "x-client-action-id"

--- a/cellarium/cas/endpoints.py
+++ b/cellarium/cas/endpoints.py
@@ -4,6 +4,8 @@ _API_GENERAL_ENDPOINT_PREFIX = f"{_API_BASE_ENDPOINT}/cellarium-general"
 # General
 VALIDATE_TOKEN = f"{_API_GENERAL_ENDPOINT_PREFIX}/validate-token"
 APPLICATION_INFO = f"{_API_GENERAL_ENDPOINT_PREFIX}/application-info"
+FEEDBACK_OPT_OUT = f"{_API_GENERAL_ENDPOINT_PREFIX}/feedback/opt-out"
+FEEDBACK_ANSWER = f"{_API_GENERAL_ENDPOINT_PREFIX}/feedback/answer?client_session_id={{client_session_id}}&client_action_id={{client_action_id}}"
 GET_FEATURE_SCHEMAS = f"{_API_GENERAL_ENDPOINT_PREFIX}/feature-schemas"
 GET_SCHEMA_BY_NAME = f"{_API_GENERAL_ENDPOINT_PREFIX}/feature-schema/{{schema_name}}"
 LIST_MODELS = f"{_API_GENERAL_ENDPOINT_PREFIX}/list-models"

--- a/cellarium/cas/resources/feedback_template.html
+++ b/cellarium/cas/resources/feedback_template.html
@@ -1,0 +1,11 @@
+<div>
+  <hr/>
+  <p>We're happy that you are using the Cell Annotation Service! We'd love to hear about your experience and how we can improve.</p>
+  <p><a href={link} target="_blank">Please click here to provide feedback and increase your weekly quota!</a></p>
+  <p>If you'd like to opt out, you can run the following command in a cell:</p>
+  <p><code>[cas client].feedback_opt_out()</code></p>
+  <p>
+    where <code>[cas client]</code> is the name of the CAS client instance.
+  </p>
+  <hr/>
+</div>

--- a/cellarium/cas/service.py
+++ b/cellarium/cas/service.py
@@ -295,7 +295,7 @@ class CASAPIService(_BaseService):
 
     def feedback_opt_out(self) -> t.Dict[str, str]:
         """
-        Opt out of future feedback requests/
+        Opt out of future feedback requests.
 
         Refer to API Docs:
         {api_url}/api/docs#/cellarium-general/feedback/opt-out

--- a/cellarium/cas/service.py
+++ b/cellarium/cas/service.py
@@ -56,7 +56,6 @@ class _BaseService:
         *args,
         **kwargs,
     ):
-
         self.api_token = api_token
         self.api_url = api_url
         self.client_session_id = client_session_id
@@ -103,9 +102,9 @@ class _BaseService:
             raise exceptions.HTTPError404(message)
 
         elif (
-            constants.HTTP.STATUS_500_INTERNAL_SERVER_ERROR <=
-            status_code <=
-            constants.HTTP.STATUS_511_NETWORK_AUTHENTICATION_REQUIRED
+            constants.HTTP.STATUS_500_INTERNAL_SERVER_ERROR
+            <= status_code
+            <= constants.HTTP.STATUS_511_NETWORK_AUTHENTICATION_REQUIRED
         ):
             raise exceptions.HTTPError5XX(message)
         else:

--- a/cellarium/cas/service.py
+++ b/cellarium/cas/service.py
@@ -2,6 +2,9 @@ import asyncio
 import json
 import ssl
 import typing as t
+from contextlib import ContextDecorator
+from contextvars import ContextVar
+from uuid import UUID, uuid4
 
 import aiohttp
 import certifi
@@ -15,6 +18,25 @@ if settings.is_interactive_environment():
     print("Running in an interactive environment, applying nest_asyncio")
     nest_asyncio.apply()
 
+# Context variable to track the action id for the current context
+client_action_id = ContextVar("action_id", default=None)
+
+
+class action_context_manager(ContextDecorator):
+    """
+    Handle the lifecycle of an action id for the current context.
+
+    Add the `@action_context_manager` decorator around methods in the client methods that should
+    have a common action id.
+    """
+
+    def __enter__(self):
+        self.t = client_action_id.set(uuid4())
+        return self
+
+    def __exit__(self, *exc):
+        client_action_id.reset(self.t)
+
 
 class _BaseService:
     """
@@ -23,11 +45,21 @@ class _BaseService:
 
     :param api_token: A token that could be authenticated by Cellarium Cloud Backend API service
     :param api_url: URL of the Cellarium Cloud Backend API service
+    :param client_session_id: A unique identifier for the current client session
     """
 
-    def __init__(self, api_token: str, api_url: str = settings.CELLARIUM_CLOUD_BACKEND_URL, *args, **kwargs):
+    def __init__(
+        self,
+        api_token: str,
+        api_url: str = settings.CELLARIUM_CLOUD_BACKEND_URL,
+        client_session_id: UUID = None,
+        *args,
+        **kwargs,
+    ):
+
         self.api_token = api_token
         self.api_url = api_url
+        self.client_session_id = client_session_id
         super().__init__(*args, **kwargs)
 
     def _get_endpoint_url(self, endpoint: str) -> str:
@@ -38,6 +70,20 @@ class _BaseService:
         :return: Full url with backend domains/subdomains and endpoint joined
         """
         return f"{self.api_url}/{endpoint}"
+
+    def _get_headers(self) -> t.Dict[str, str]:
+        """
+        Get the headers to include in the request
+
+        :return: Headers dictionary
+        """
+        headers = {constants.Headers.authorization: f"Bearer {self.api_token}"}
+        if self.client_session_id:
+            headers[constants.Headers.client_session_id] = str(self.client_session_id)
+        action_id = client_action_id.get()
+        if action_id:
+            headers[constants.Headers.client_action_id] = str(action_id)
+        return headers
 
     @staticmethod
     def raise_response_exception(status_code: int, detail: str) -> None:
@@ -57,9 +103,9 @@ class _BaseService:
             raise exceptions.HTTPError404(message)
 
         elif (
-            constants.HTTP.STATUS_500_INTERNAL_SERVER_ERROR
-            <= status_code
-            <= constants.HTTP.STATUS_511_NETWORK_AUTHENTICATION_REQUIRED
+            constants.HTTP.STATUS_500_INTERNAL_SERVER_ERROR <=
+            status_code <=
+            constants.HTTP.STATUS_511_NETWORK_AUTHENTICATION_REQUIRED
         ):
             raise exceptions.HTTPError5XX(message)
         else:
@@ -94,14 +140,14 @@ class _BaseService:
         :return: Response object
         """
         url = self._get_endpoint_url(endpoint)
-        headers = {"Authorization": f"Bearer {self.api_token}"}
+        headers = self._get_headers()
         response = requests.get(url=url, headers=headers)
         self.__validate_requests_response(response=response)
         return response
 
     def post(self, endpoint: str, data: t.Optional[t.Dict] = None) -> requests.Response:
         url = self._get_endpoint_url(endpoint)
-        headers = {"Authorization": f"Bearer {self.api_token}"}
+        headers = self._get_headers()
         response = requests.post(url=url, headers=headers, json=data)
         self.__validate_requests_response(response=response)
         return response
@@ -205,7 +251,7 @@ class _BaseService:
         """
         url = self._get_endpoint_url(endpoint=endpoint)
         _data = data if data is not None else {}
-        _headers = {"Authorization": f"Bearer {self.api_token}"}
+        _headers = self._get_headers()
 
         if headers is not None:
             _headers.update(headers)
@@ -224,7 +270,7 @@ class CASAPIService(_BaseService):
     Class with all the API methods of Cellarium Cloud CAS infrastructure.
     """
 
-    def validate_token(self) -> None:
+    def validate_token(self) -> t.Dict[str, str]:
         """
         Validate user given API token.
         Would raise 401 Unauthorized if token is invalid.
@@ -232,9 +278,9 @@ class CASAPIService(_BaseService):
         Refer to API Docs:
         {api_url}/api/docs#/cellarium-general/validate_token_api_cellarium_general_validate_token_get
 
-        :return: Void
+        :return: Dictionary with basic user information
         """
-        self.get(endpoint=endpoints.VALIDATE_TOKEN)
+        return self.get_json(endpoint=endpoints.VALIDATE_TOKEN)
 
     def get_application_info(self) -> t.Dict[str, str]:
         """
@@ -246,6 +292,30 @@ class CASAPIService(_BaseService):
         :return: Dictionary with application info
         """
         return self.get_json(endpoint=endpoints.APPLICATION_INFO)
+
+    def feedback_opt_out(self) -> t.Dict[str, str]:
+        """
+        Opt out of future feedback requests/
+
+        Refer to API Docs:
+        {api_url}/api/docs#/cellarium-general/feedback/opt-out
+        :return: Dictionary with basic user information
+        """
+        return self.post_json(endpoint=endpoints.FEEDBACK_OPT_OUT)
+
+    def get_feedback_answer_link(self) -> str:
+        """
+        Retrieve a link to answer feedback questions
+
+        Refer to API Docs:
+        {api_url}/api/docs#/cellarium-general/feedback/answer
+        :return: Link to answer feedback questions
+        """
+        return self._get_endpoint_url(
+            endpoints.FEEDBACK_ANSWER.format(
+                client_session_id=self.client_session_id, client_action_id=client_action_id.get()
+            )
+        )
 
     def get_feature_schemas(self) -> t.List[str]:
         """

--- a/tests/unit/test_cas_client.py
+++ b/tests/unit/test_cas_client.py
@@ -184,6 +184,7 @@ class TestCasClient:
                     "schema_name": TEST_SCHEMA,
                     "is_default_model": True,
                     "embedding_dimension": 512,
+                    "description": "",
                 }
             ],
         )
@@ -245,7 +246,12 @@ class TestCasClient:
         return anndata.AnnData(X=X, obs=obs, dtype=np.float32)
 
     def _mock_response(
-        self, url: str, status_code: int, response_body: dict | list, method: str = "get", post_data: dict | list = None
+        self,
+        url: str,
+        status_code: int,
+        response_body: t.Union[dict, list],
+        method: str = "get",
+        post_data: t.Union[dict, list] = None,
     ):
         response = mock(aiohttp.ClientResponse)
         response.status_code = status_code
@@ -260,7 +266,7 @@ class TestCasClient:
             raise ValueError(f"Unsupported method: {method}")
 
     def _mock_async_post_response(
-        self, url: str, status_code: int, response_body: dict | list, post_data: dict | list = None
+        self, url: str, status_code: int, response_body: t.Union[dict, list], post_data: t.Union[dict, list] = None
     ):
         # Mock response
         response = mock(aiohttp.ClientResponse)
@@ -279,7 +285,7 @@ class TestCasClient:
         self.async_post_mocks[url] = session
 
     def _verify_headers(
-        self, urls: list[str], async_post_urls: list[str], active_session_id: str, num__expected_actions: int
+        self, urls: t.List[str], async_post_urls: t.List[str], active_session_id: str, num__expected_actions: int
     ):
         """
         Verify that the expected header values were sent.

--- a/tests/unit/test_cas_client.py
+++ b/tests/unit/test_cas_client.py
@@ -24,7 +24,7 @@ NP_RANDOM_STATE = np.random.RandomState(0)
 
 class TestCasClient:
     def setup_method(self) -> None:
-        # This is tracks all async post mocks that are created where the key is the url and the value is the
+        # This tracks all async post mocks that are created where the key is the url and the value is the
         # session mock object. Used for verifying that the calls were made.
         self.async_post_mocks: t.Dict[str, aiohttp.ClientSession] = {}
         # Create a new event loop for each test since this is an async-heavy test and this avoid unexpected behavior
@@ -78,7 +78,7 @@ class TestCasClient:
         cas_client = CASClient(api_token=TEST_TOKEN, api_url=TEST_URL)
 
         response = cas_client.annotate_matrix_cell_type_summary_statistics_strategy(
-            matrix=self._mock_matrix(num_cells=num_cells), chunk_size=100
+            matrix=self._mock_anndata_matrix(num_cells=num_cells), chunk_size=100
         )
 
         assert len(response) == num_cells
@@ -107,7 +107,7 @@ class TestCasClient:
 
         # This should cause 10 chunks to be sent
         response = cas_client.annotate_matrix_cell_type_summary_statistics_strategy(
-            matrix=self._mock_matrix(num_cells=num_cells), chunk_size=10
+            matrix=self._mock_anndata_matrix(num_cells=num_cells), chunk_size=10
         )
 
         assert len(response) == num_cells
@@ -136,12 +136,12 @@ class TestCasClient:
 
         # This should cause 10 chunks to be sent
         response1 = cas_client.annotate_matrix_cell_type_summary_statistics_strategy(
-            matrix=self._mock_matrix(num_cells=num_cells), chunk_size=10
+            matrix=self._mock_anndata_matrix(num_cells=num_cells), chunk_size=10
         )
         assert len(response1) == num_cells
 
         response2 = cas_client.annotate_matrix_cell_type_summary_statistics_strategy(
-            matrix=self._mock_matrix(num_cells=num_cells), chunk_size=10
+            matrix=self._mock_anndata_matrix(num_cells=num_cells), chunk_size=10
         )
         assert len(response2) == num_cells
 
@@ -238,7 +238,7 @@ class TestCasClient:
             ],
         )
 
-    def _mock_matrix(self, num_features: int = 3, num_cells: int = 3) -> anndata.AnnData:
+    def _mock_anndata_matrix(self, num_features: int = 3, num_cells: int = 3) -> anndata.AnnData:
         d = NP_RANDOM_STATE.randint(0, 500, size=(num_cells, num_features))
         X = sp.csr_matrix(d)
         obs = pd.DataFrame(index=[f"cell{i}" for i in range(num_cells)])

--- a/tests/unit/test_cas_client.py
+++ b/tests/unit/test_cas_client.py
@@ -1,0 +1,320 @@
+import asyncio
+import datetime
+import typing as t
+
+import aiohttp
+import anndata
+import numpy as np
+import pandas as pd
+import requests
+import scipy.sparse as sp
+from mockito import ANY, captor, mock, unstub, verify, when
+from mockito.matchers import ArgumentCaptor
+
+from cellarium.cas import constants
+from cellarium.cas.client import CASClient
+from tests.unit.test_utils import async_context_manager_decorator, async_return
+
+TEST_TOKEN = "test_token"
+TEST_URL = "https://cas-host.io"
+TEST_SCHEMA = "schema1"
+
+NP_RANDOM_STATE = np.random.RandomState(0)
+
+
+class TestCasClient:
+    def setup_method(self) -> None:
+        # This is tracks all async post mocks that are created where the key is the url and the value is the
+        # session mock object. Used for verifying that the calls were made.
+        self.async_post_mocks: t.Dict[str, aiohttp.ClientSession] = {}
+        # Create a new event loop for each test since this is an async-heavy test and this avoid unexpected behavior
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    def teardown_method(self) -> None:
+        unstub()
+        self.async_post_mocks = {}
+
+    def test_initialize(self):
+        self._mock_constructor_calls()
+
+        cas_client = CASClient(api_token=TEST_TOKEN, api_url=TEST_URL)
+        # Verify that the expected header values were sent.
+        # E.g. make sure that the tokens all match and that the session and action ids all match.
+        sent_tokens: t.Set[str] = set()
+        sent_sessions: t.Set[str] = set()
+        sent_actions: t.Set[str] = set()
+        expected_calls = [
+            f"{TEST_URL}/api/cellarium-general/validate-token",
+            f"{TEST_URL}/api/cellarium-general/application-info",
+            f"{TEST_URL}/api/cellarium-general/list-models",
+            f"{TEST_URL}/api/cellarium-general/feature-schemas",
+        ]
+
+        for url in expected_calls:
+            header_captor: ArgumentCaptor[t.Dict[str, any]] = captor()
+            verify(requests).get(url=url, headers=header_captor)
+            headers = header_captor.value
+            if constants.Headers.authorization in headers:
+                sent_tokens.add(headers[constants.Headers.authorization])
+            if constants.Headers.client_session_id in headers:
+                sent_sessions.add(headers[constants.Headers.client_session_id])
+            if constants.Headers.client_action_id in headers:
+                sent_actions.add(headers[constants.Headers.client_action_id])
+
+        assert len(sent_tokens) == 1
+        assert f"Bearer {TEST_TOKEN}" in sent_tokens
+
+        assert len(sent_sessions) == 1
+        assert str(cas_client.client_session_id) in sent_sessions
+
+        assert len(sent_actions) == 1
+
+    def test_annotate_matrix_cell_type_summary_statistics_strategy(self):
+        num_cells = 10
+        self._mock_constructor_calls()
+        self._mock_annotate_matrix_cell_type_summary_statistics_strategy_calls(num_cells=num_cells)
+
+        cas_client = CASClient(api_token=TEST_TOKEN, api_url=TEST_URL)
+
+        response = cas_client.annotate_matrix_cell_type_summary_statistics_strategy(
+            matrix=self._mock_matrix(num_cells=num_cells), chunk_size=100
+        )
+
+        assert len(response) == num_cells
+        self._verify_headers(
+            urls=[
+                f"{TEST_URL}/api/cellarium-general/validate-token",
+                f"{TEST_URL}/api/cellarium-general/quota",
+                f"{TEST_URL}/api/cellarium-general/application-info",
+                f"{TEST_URL}/api/cellarium-general/list-models",
+                f"{TEST_URL}/api/cellarium-general/feature-schemas",
+                f"{TEST_URL}/api/cellarium-general/feature-schema/{TEST_SCHEMA}",
+            ],
+            async_post_urls=[
+                f"{TEST_URL}/api/cellarium-cell-operations/annotate-cell-type-summary-statistics-strategy"
+            ],
+            active_session_id=cas_client.client_session_id,
+            num__expected_actions=2,  # one for initialization and one for the annotation
+        )
+
+    def test_annotate_matrix_cell_type_summary_statistics_strategy_with_chunking(self):
+        num_cells = 100
+        self._mock_constructor_calls()
+        self._mock_annotate_matrix_cell_type_summary_statistics_strategy_calls(num_cells=num_cells)
+
+        cas_client = CASClient(api_token=TEST_TOKEN, api_url=TEST_URL)
+
+        # This should cause 10 chunks to be sent
+        response = cas_client.annotate_matrix_cell_type_summary_statistics_strategy(
+            matrix=self._mock_matrix(num_cells=num_cells), chunk_size=10
+        )
+
+        assert len(response) == num_cells
+        self._verify_headers(
+            urls=[
+                f"{TEST_URL}/api/cellarium-general/validate-token",
+                f"{TEST_URL}/api/cellarium-general/quota",
+                f"{TEST_URL}/api/cellarium-general/application-info",
+                f"{TEST_URL}/api/cellarium-general/list-models",
+                f"{TEST_URL}/api/cellarium-general/feature-schemas",
+                f"{TEST_URL}/api/cellarium-general/feature-schema/{TEST_SCHEMA}",
+            ],
+            async_post_urls=[
+                f"{TEST_URL}/api/cellarium-cell-operations/annotate-cell-type-summary-statistics-strategy"
+            ],
+            active_session_id=cas_client.client_session_id,
+            num__expected_actions=2,  # one for initialization and one for the annotation
+        )
+
+    def test_annotate_matrix_cell_type_summary_statistics_strategy_with_several_calls(self):
+        num_cells = 100
+        self._mock_constructor_calls()
+        self._mock_annotate_matrix_cell_type_summary_statistics_strategy_calls(num_cells=num_cells)
+
+        cas_client = CASClient(api_token=TEST_TOKEN, api_url=TEST_URL)
+
+        # This should cause 10 chunks to be sent
+        response1 = cas_client.annotate_matrix_cell_type_summary_statistics_strategy(
+            matrix=self._mock_matrix(num_cells=num_cells), chunk_size=10
+        )
+        assert len(response1) == num_cells
+
+        response2 = cas_client.annotate_matrix_cell_type_summary_statistics_strategy(
+            matrix=self._mock_matrix(num_cells=num_cells), chunk_size=10
+        )
+        assert len(response2) == num_cells
+
+        self._verify_headers(
+            urls=[
+                f"{TEST_URL}/api/cellarium-general/validate-token",
+                f"{TEST_URL}/api/cellarium-general/quota",
+                f"{TEST_URL}/api/cellarium-general/application-info",
+                f"{TEST_URL}/api/cellarium-general/list-models",
+                f"{TEST_URL}/api/cellarium-general/feature-schemas",
+                f"{TEST_URL}/api/cellarium-general/feature-schema/{TEST_SCHEMA}",
+            ],
+            async_post_urls=[
+                f"{TEST_URL}/api/cellarium-cell-operations/annotate-cell-type-summary-statistics-strategy"
+            ],
+            active_session_id=cas_client.client_session_id,
+            num__expected_actions=3,  # one for initialization and one for *each* annotation call
+        )
+
+    def _mock_constructor_calls(self):
+        """
+        Mocks the calls made by the CASClient constructor
+        """
+        self._mock_response(
+            url=f"{TEST_URL}/api/cellarium-general/validate-token",
+            status_code=200,
+            response_body={"username": "foo", "email": "foo@bar.com"},
+        )
+        self._mock_response(
+            url=f"{TEST_URL}/api/cellarium-general/application-info",
+            status_code=200,
+            response_body={"application_version": "1.0.0", "default_feature_schema": "foo"},
+        )
+        self._mock_response(
+            url=f"{TEST_URL}/api/cellarium-general/list-models",
+            status_code=200,
+            response_body=[
+                {
+                    "model_name": "human-pca-001",
+                    "schema_name": TEST_SCHEMA,
+                    "is_default_model": True,
+                    "embedding_dimension": 512,
+                }
+            ],
+        )
+        self._mock_response(
+            url=f"{TEST_URL}/api/cellarium-general/feature-schemas",
+            status_code=200,
+            response_body=[
+                {"schema_name": TEST_SCHEMA},
+            ],
+        )
+
+    def _mock_annotate_matrix_cell_type_summary_statistics_strategy_calls(
+        self, num_cells: int = 3, num_features: int = 3
+    ):
+        """
+        Mocks the calls made by the CASClient to do an annotation call with the summary statistics strategy
+        """
+        self._mock_response(
+            url=f"{TEST_URL}/api/cellarium-general/feature-schema/{TEST_SCHEMA}",
+            status_code=200,
+            response_body=[f"field{i}" for i in range(num_features)],
+        )
+        self._mock_response(
+            url=f"{TEST_URL}/api/cellarium-general/quota",
+            status_code=200,
+            response_body={
+                "user_id": 0,
+                "quota": 1000,
+                "remaining_quota": 1000,
+                "quota_reset_date": datetime.datetime.today() + 7 * datetime.timedelta(days=1),
+            },
+        )
+        self._mock_async_post_response(
+            url=f"{TEST_URL}/api/cellarium-cell-operations/annotate-cell-type-summary-statistics-strategy",
+            status_code=200,
+            response_body=[
+                {
+                    "query_cell_id": f"cell{i}",
+                    "matches": [
+                        {
+                            "cell_type": "erythrocyte",
+                            "cell_count": 100,
+                            "min_distance": 12.0,
+                            "p25_distance": 11.0,
+                            "median_distance": 10.0,
+                            "p75_distance": 9.0,
+                            "max_distance": 13.0,
+                        }
+                    ],
+                }
+                for i in range(num_cells)
+            ],
+        )
+
+    def _mock_matrix(self, num_features: int = 3, num_cells: int = 3) -> anndata.AnnData:
+        d = NP_RANDOM_STATE.randint(0, 500, size=(num_cells, num_features))
+        X = sp.csr_matrix(d)
+        obs = pd.DataFrame(index=[f"cell{i}" for i in range(num_cells)])
+        return anndata.AnnData(X=X, obs=obs, dtype=np.float32)
+
+    def _mock_response(
+        self, url: str, status_code: int, response_body: dict | list, method: str = "get", post_data: dict | list = None
+    ):
+        response = mock(aiohttp.ClientResponse)
+        response.status_code = status_code
+        when(response).json().thenReturn(response_body)
+
+        if method == "get":
+            when(requests).get(url=url, headers=ANY).thenReturn(response)
+        elif method == "post":
+            body = post_data if post_data is not None else ANY
+            when(requests).post(url=url, headers=ANY, json=body).thenReturn(response)
+        else:
+            raise ValueError(f"Unsupported method: {method}")
+
+    def _mock_async_post_response(
+        self, url: str, status_code: int, response_body: dict | list, post_data: dict | list = None
+    ):
+        # Mock response
+        response = mock(aiohttp.ClientResponse)
+        response.status = status_code
+        when(response).json().thenReturn(async_return(response_body))
+        response = async_context_manager_decorator(response)
+
+        # Mock the session
+        session = mock(aiohttp.ClientSession)
+        body = post_data if post_data is not None else ANY
+        session = async_context_manager_decorator(session)
+        when(session).post(url, headers=ANY, data=body).thenReturn(response)
+
+        # Mock the aiohttp.ClientSession constructor
+        when(aiohttp).ClientSession(connector=ANY, timeout=ANY).thenReturn(session)
+        self.async_post_mocks[url] = session
+
+    def _verify_headers(
+        self, urls: list[str], async_post_urls: list[str], active_session_id: str, num__expected_actions: int
+    ):
+        """
+        Verify that the expected header values were sent.
+        E.g. make sure that the tokens all match and that the session and action ids all match.
+        """
+        sent_tokens: t.Set[str] = set()
+        sent_sessions: t.Set[str] = set()
+        sent_actions: t.Set[str] = set()
+
+        for url in urls:
+            header_captor: ArgumentCaptor[t.Dict[str, any]] = captor()
+            verify(requests, atleast=1).get(url=url, headers=header_captor)
+            headers = header_captor.value
+            if constants.Headers.authorization in headers:
+                sent_tokens.add(headers[constants.Headers.authorization])
+            if constants.Headers.client_session_id in headers:
+                sent_sessions.add(headers[constants.Headers.client_session_id])
+            if constants.Headers.client_action_id in headers:
+                sent_actions.add(headers[constants.Headers.client_action_id])
+
+        for url in async_post_urls or []:
+            header_captor: ArgumentCaptor[t.Dict[str, any]] = captor()
+            verify(self.async_post_mocks[url], atleast=1).post(url, headers=header_captor, data=ANY)
+            headers = header_captor.value
+            if constants.Headers.authorization in headers:
+                sent_tokens.add(headers[constants.Headers.authorization])
+            if constants.Headers.client_session_id in headers:
+                sent_sessions.add(headers[constants.Headers.client_session_id])
+            if constants.Headers.client_action_id in headers:
+                sent_actions.add(headers[constants.Headers.client_action_id])
+
+        assert len(sent_tokens) == 1
+        assert f"Bearer {TEST_TOKEN}" in sent_tokens
+
+        assert len(sent_sessions) == 1
+        assert str(active_session_id) in sent_sessions
+
+        assert len(sent_actions) == num__expected_actions

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,40 @@
+import asyncio
+import typing as t
+
+from mockito import when
+
+
+def async_context_manager_decorator(mocked_object: object) -> object:
+    """
+    Takes in a mock object and decorates it so that it can be used as an async context manager.
+    E.g. as: `async with mock_object as obj: ...`
+
+    The `__aenter__` method simpy returns the mock object, and the `__aexit__` method returns `None`.
+
+    :param mocked_object: The mock object to decorate. Note: Mockito doesn't expose their mock object type.
+
+    :return: The decorated mock object.
+    """
+
+    async def __aenter__(*_):
+        return mocked_object
+
+    async def __aexit__(*_):
+        return None
+
+    when(mocked_object).__aenter__().thenAnswer(__aenter__)
+    when(mocked_object).__aexit__(...).thenAnswer(__aexit__)
+
+    return mocked_object
+
+
+def async_return(result: t.Any) -> asyncio.Future:
+    """
+    Return a result from an async function. Useful for mocking client calls.
+
+    :param result: The result to return.
+    :return: An asyncio Future that will return the result.
+    """
+    f = asyncio.Future()
+    f.set_result(result)
+    return f


### PR DESCRIPTION
and give users an option to opt out

The link looks something like:
![image](https://github.com/cellarium-ai/cellarium-cas/assets/5633787/563c9334-f9fe-413d-9e95-c52f399f806c)

The link takes the user to `<casapi>/api/cellarium-general/feedback/answer?client_session_id=<session>&client_action_id=<action>`
(where session is unique to the client instance and action is unique to a client method (based on the `@action_context_manager()` annotation as a way to group api calls together in logs.

...this then redirects the user to a form url as defined in the service.  This will allow us easier control in changing forms or altogether removing feedback requests.

This also prints the username and session id when creating the initial connection (helpful for support calls)