### PR TITLE
CAS-39 package and deploy

### DIFF
--- a/.github/actions/pypi-deploy/action.yaml
+++ b/.github/actions/pypi-deploy/action.yaml
@@ -1,0 +1,35 @@
+name: Build and publish to PyPI 
+description: Build the CAS client and deploy it to PyPI
+inputs:
+  python-version:
+    required: true
+    description: "Python version to build the package with"
+    default: "3.7"
+  pypi-type:
+    required: true
+    description: "The type of PyPI deployment to perform: test or prod"
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements/base.txt
+        pip install build
+
+      shell: bash
+
+    - name: Build Package
+      run: python -m build
+      shell: bash
+
+    - name: Publish Package Distributions to Appropriate PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: ${{ inputs.pypi-type == 'test' && 'https://test.pypi.org/legacy/' || '' }}
+    

--- a/.github/actions/pypi-deploy/action.yaml
+++ b/.github/actions/pypi-deploy/action.yaml
@@ -11,6 +11,15 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Verify git environment
+      run: |
+        if [ "${{ github.ref_type }}" == "tag" ]; then
+          echo "Building and publishing package for tag ${{ github.ref }}."
+        else
+          echo "::error::This action can only be run on a tag."
+          exit 1
+        fi
+      shell: bash
     - name: Setup Python
       uses: actions/setup-python@v5
       with:

--- a/.github/actions/unit-tests/action.yaml
+++ b/.github/actions/unit-tests/action.yaml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -1,16 +1,56 @@
 name: Cellarium CAS Repository Update Workflow
-on: [push, workflow_dispatch]
+on: 
+  push:
+  workflow_dispatch:
+    inputs:
+      pypi-type:
+        description: 'The type of PyPI deployment to perform or none'
+        required: true
+        default: 'none'
+        type: choice
+        options:
+          - none
+          - test
+          - prod
+      skip-unit-tests:
+        description: 'Skip the unit tests'
+        required: false
+        default: false
+        type: boolean
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.inputs.skip-unit-tests }}
     strategy:
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/unit-tests
         env:
           TEST_API_TOKEN: ${{ secrets.TEST_API_TOKEN }}
           TEST_API_URL: ${{ secrets.TEST_API_URL }}
         with:
           python-version: ${{ matrix.python-version }}
+  publish-to-pypi:
+    runs-on: ubuntu-latest
+    needs:
+      - unit-tests
+    if: |
+      always()
+      && !cancelled()
+      && contains(fromJson('["skipped", "success"]'), needs.unit-tests.result)
+      && github.event_name == 'workflow_dispatch'
+      && github.event.inputs.pypi-type != 'none'
+    permissions:
+      id-token: write
+    environment:
+      name: ${{ inputs.pypi-type == 'prod' && 'pypi' || 'test-pypi'}}
+      url: ${{ inputs.pypi-type == 'prod' && 'https://pypi.org/p/cellarium-cas' || 'https://test.pypi.org/p/cellarium-cas'}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/pypi-deploy
+        with:
+          python-version: '3.7'
+          pypi-type: ${{ inputs.pypi-type }}
+          

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This codebase contains the Python client library for using Cellarium Cell Annota
 
 # Installation
 ```
-$ pip install git+https://github.com/broadinstitute/cell-annotation-service-client.git
+$ pip install cellarium-cas
 ```
 # Usage
 To use Cellarium CAS, create a client instance with your API token:
@@ -14,7 +14,7 @@ from cellarium.cas import CASClient
 api_token = "a_very_long_string_with_some_symbols"
 cas = CASClient(
   api_token=api_token,
-  api_url=<optional url to connect to a non-standard CAS server>
+  api_url="<optional url to connect to a non-standard CAS server>"
 )
 ```
 

--- a/cellarium/cas/service.py
+++ b/cellarium/cas/service.py
@@ -17,15 +17,15 @@ if settings.is_interactive_environment():
 
 
 class _BaseService:
+    """
+    Base class for communicating with a Cellarium Cloud API service
+    It leverages async request library `aiohttp` to asynchronously execute HTTP requests.
+
+    :param api_token: A token that could be authenticated by Cellarium Cloud Backend API service
+    :param api_url: URL of the Cellarium Cloud Backend API service
+    """
 
     def __init__(self, api_token: str, api_url: str = settings.CELLARIUM_CLOUD_BACKEND_URL, *args, **kwargs):
-        """
-        Base class for communicating with a Cellarium Cloud API service
-        It leverages async request library `aiohttp` to asynchronously execute HTTP requests.
-
-        :param api_token: A token that could be authenticated by Cellarium Cloud Backend API service
-        :param api_url: URL of the Cellarium Cloud Backend API service
-        """
         self.api_token = api_token
         self.api_url = api_url
         super().__init__(*args, **kwargs)

--- a/cellarium/cas/version.py
+++ b/cellarium/cas/version.py
@@ -1,18 +1,31 @@
 import os
 import re
-from importlib.metadata import PackageNotFoundError, version
+from sys import version_info as python_version_info
 
 
 def get_version() -> str:
     """
-    Get the version of the application base on git tag.
+    Get the version of the application based on the git tag.
 
     :return: The version of the application.
     """
-    try:
-        return version("cellarium-cas")
-    except PackageNotFoundError:
-        return os.environ.get("CAS_VERSION", "0.0.1")
+
+    if python_version_info.major == 3 and python_version_info.minor >= 8:
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            return version("cellarium-cas")
+        except PackageNotFoundError:
+            return os.environ.get("CAS_VERSION", "0.0.1")
+    elif python_version_info.major == 3 and python_version_info.minor == 7:
+        from importlib_metadata import PackageNotFoundError, version
+
+        try:
+            return version("cellarium-cas")
+        except PackageNotFoundError:
+            return os.environ.get("CAS_VERSION", "0.0.1")
+    else:
+        raise Exception("Unsupported Python version. Please use Python 3.7 or later.")
 
 
 def _is_release_version(version_string) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,11 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "cellarium-cas"
 authors = [
-    { name="Cellarium AI", email="info@cellarium.ai" }
+    { name="Cellarium CAS", email="cas-support@broadinstitute.org" }
 ]
 description = "Cellarium Cell Annotation Service client tool"
 requires-python = ">=3.7"
-license = {file = "LICENSE.md"}
+license = {file = "LICENSE"}
 classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
@@ -26,7 +26,7 @@ include = ["cellarium.*"]
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements/base.txt"]}
 optional-dependencies = {docs = { file = ["requirements/docs.txt"] }, test = { file = ["requirements/test.txt"]}, scanpy = { file = ["requirements/scanpy.txt"]}}
-readme = {file = ["README.md"]}
+readme = {file = ["README.md"], content-type = "text/markdown"}
 
 [project.urls]
 "Homepage" = "https://cellarium.ai"

--- a/tests/unit/test_cas_service.py
+++ b/tests/unit/test_cas_service.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import aiohttp
 import pytest
 import requests
@@ -96,7 +98,7 @@ class TestCasService:
         with pytest.raises(exceptions.HTTPError403, match="Unauthorized"):
             self.cas_service.get_feature_schema_by(name="schema1")
 
-    def _mock_response(self, url: str, token: str, status_code: int, response_body: dict | list):
+    def _mock_response(self, url: str, token: str, status_code: int, response_body: t.Union[dict, list]):
         response = mock(aiohttp.ClientResponse)
         response.status_code = status_code
         when(response).json().thenReturn(response_body)


### PR DESCRIPTION
Package and deploy CAS Client to PyPI.  Note: this adds onto the `main-workflow.yaml` action as an optional last step.

Note:
- The action must be manually run against a release tag
- Allows opting out of unit tests (though default is to run them)

To make this work, I had to do some tweaking of the project config (e.g. pointing to correct license file, use a working email, specify that the read me is markdown)

This PR also make sure that we are able to test and build for python versions 3.7, 3.8, 3.9 and 3.10 so there are some small changes to make it build in 3.7.  I have it building with the lowest supported version by default to presumably have the highest compatibility.