### PR TITLE
Chore: Remove dev / prod settings

### DIFF
--- a/cellarium/cas/settings.py
+++ b/cellarium/cas/settings.py
@@ -5,6 +5,7 @@ MAX_RETRY_DELAY = 32
 AIOHTTP_TOTAL_TIMEOUT_SECONDS = 750
 AIOHTTP_READ_TIMEOUT_SECONDS = 730
 MAX_CHUNK_SIZE_SEARCH_METHOD = 500
+CELLARIUM_CLOUD_BACKEND_URL = "https://cellarium-cloud-api.cellarium.ai"
 
 
 def is_interactive_environment() -> bool:

--- a/cellarium/cas/settings/__init__.py
+++ b/cellarium/cas/settings/__init__.py
@@ -1,9 +1,0 @@
-from ..version import get_version_environment
-from .base import *  # noqa
-
-VERSION_ENVIRONMENT = get_version_environment()
-
-if VERSION_ENVIRONMENT == "development" or VERSION_ENVIRONMENT == "test":
-    from .development import *  # noqa
-else:
-    from .production import *  # noqa

--- a/cellarium/cas/settings/development.py
+++ b/cellarium/cas/settings/development.py
@@ -1,1 +1,0 @@
-CELLARIUM_CLOUD_BACKEND_URL = "https://cellarium-cloud-api-dev.cellarium.ai"

--- a/cellarium/cas/settings/production.py
+++ b/cellarium/cas/settings/production.py
@@ -1,1 +1,0 @@
-CELLARIUM_CLOUD_BACKEND_URL = "https://cellarium-cloud-api.cellarium.ai"

--- a/cellarium/cas/version.py
+++ b/cellarium/cas/version.py
@@ -1,5 +1,4 @@
 import os
-import re
 from sys import version_info as python_version_info
 
 
@@ -26,53 +25,3 @@ def get_version() -> str:
             return os.environ.get("CAS_VERSION", "0.0.1")
     else:
         raise Exception("Unsupported Python version. Please use Python 3.7 or later.")
-
-
-def _is_release_version(version_string) -> bool:
-    """
-    Check if the version string is a release version. Release version is a string that has the format of
-    "major.minor.patch".
-
-    Reference: https://semver.org/
-
-    :param version_string: The version string to check
-
-    :return: True if the version string is a release version, False otherwise.
-    """
-    pattern = r"^\d+\.\d+\.\d+$"
-    return re.match(pattern, version_string) is not None
-
-
-def _is_pre_release_version(version_string) -> bool:
-    """
-    Check if the version string is a pre-release version. Pre-release version is a string that has the format of
-    "major.minor.patch-(alpha|beta|rc).patch".
-
-    Reference: https://semver.org/
-
-    :param version_string: The version string to check
-
-    :return: True if the version string is a pre-release version, False otherwise.
-    """
-    pattern = r"^\d+\.\d+\.\d+-(alpha|beta|rc)\.\d+$"
-    return re.match(pattern, version_string) is not None
-
-
-def get_version_environment() -> str:
-    """
-    Get the environment based on the version of the application. The environment is considered as "development" if the
-    version is a pre-release version, "production" if the version is a release version, and "test" if the version is
-    neither a release version nor a pre-release version.
-
-    Exception: If the version is "0.0.1", the environment is considered as "development" because this version is
-    assigned in GitHub Actions executed on branches without a tag.
-
-    :return: The environment name of the application.
-    """
-    app_version = get_version()
-    if _is_pre_release_version(app_version) or app_version == "0.0.1":
-        return "development"
-    elif _is_release_version(app_version):
-        return "production"
-    else:
-        return "test"


### PR DESCRIPTION
Removing the dev and prod `BACKEND_URL` resulted in the removal of dev and prod settings in general, as this was the only different setting.