### PR TITLE
CAS-57 Added steps in the validation and sanitization to handle incompatible types in the anndata matrix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
   - PR tests will now fail when doc is invalid
   - Fixed bugs documentation navigation
 
+  Fixed
+  ~~~~~
+  - Added a pre-sanitization step to fix an issue where non-float32 anndata matrices would be submitted to CAS and fail
+
 1.4.12 - 2024-08-01
 -------------------
 

--- a/cellarium/cas/client.py
+++ b/cellarium/cas/client.py
@@ -179,9 +179,15 @@ class CASClient:
             cas_feature_schema_list = self.cas_api_service.get_feature_schema_by(name=feature_schema_name)
             self._feature_schemas_cache[feature_schema_name] = cas_feature_schema_list
 
+        # Make a copy of the input anndata object that we can sanitize
+        new_adata = adata.copy()
+
+        # Apply preprocessing steps that are necessary before validation and sanitization
+        preprocessing.pre_sanitize(adata=new_adata, count_matrix_input=count_matrix_name)
+
         try:
             preprocessing.validate(
-                adata=adata,
+                adata=new_adata,
                 cas_feature_schema_list=cas_feature_schema_list,
                 feature_ids_column_name=feature_ids_column_name,
                 count_matrix_input=count_matrix_name,
@@ -210,19 +216,8 @@ class CASClient:
                     f"CAS schema but in a different order. The input features will be reordered according to "
                     f"'{feature_schema_name}'"
                 )
-            if e.incompatible_x_type is not None:
-                self._print(
-                    f"CAS expects the input data matrix to be of type 'float32', but the data provided is of type "
-                    f"'{e.incompatible_x_type}'. If possible, the input data will be converted to 'float32'."
-                )
-            if e.incompatible_total_mrna_umis_type is not None:
-                self._print(
-                    f"CAS expects that, if a matrix for total mRNA UMIs is provided, it should be of type 'float32', "
-                    f"The provided total mRNA UMIs matrix is of type '{e.incompatible_total_mrna_umis_type}'. If "
-                    f"possible, the total mRNA UMIs matrix will be converted to 'float32'."
-                )
             return preprocessing.sanitize(
-                adata=adata,
+                adata=new_adata,
                 cas_feature_schema_list=cas_feature_schema_list,
                 count_matrix_input=count_matrix_name,
                 feature_ids_column_name=feature_ids_column_name,
@@ -230,7 +225,7 @@ class CASClient:
             )
         else:
             self._print(f"The input data matrix conforms with the '{feature_schema_name}' CAS schema.")
-            return adata
+            return new_adata
 
     def print_user_quota(self) -> None:
         """

--- a/cellarium/cas/client.py
+++ b/cellarium/cas/client.py
@@ -184,6 +184,7 @@ class CASClient:
                 adata=adata,
                 cas_feature_schema_list=cas_feature_schema_list,
                 feature_ids_column_name=feature_ids_column_name,
+                count_matrix_input=count_matrix_name,
             )
         except exceptions.DataValidationError as e:
             if e.extra_features > 0:
@@ -208,6 +209,17 @@ class CASClient:
                     f"The input data matrix contains all of the features specified in '{feature_schema_name}' "
                     f"CAS schema but in a different order. The input features will be reordered according to "
                     f"'{feature_schema_name}'"
+                )
+            if e.incompatible_x_type is not None:
+                self._print(
+                    f"CAS expects the input data matrix to be of type 'float32', but the data provided is of type "
+                    f"'{e.incompatible_x_type}'. If possible, the input data will be converted to 'float32'."
+                )
+            if e.incompatible_total_mrna_umis_type is not None:
+                self._print(
+                    f"CAS expects that, if a matrix for total mRNA UMIs is provided, it should be of type 'float32', "
+                    f"The provided total mRNA UMIs matrix is of type '{e.incompatible_total_mrna_umis_type}'. If "
+                    f"possible, the total mRNA UMIs matrix will be converted to 'float32'."
                 )
             return preprocessing.sanitize(
                 adata=adata,
@@ -704,6 +716,7 @@ class CASClient:
             feature_ids_column_name=feature_ids_column_name,
             feature_names_column_name=feature_names_column_name,
         )
+        
         results = self.__async_sharded_request(
             adata=matrix,
             chunk_size=chunk_size,

--- a/cellarium/cas/client.py
+++ b/cellarium/cas/client.py
@@ -716,7 +716,7 @@ class CASClient:
             feature_ids_column_name=feature_ids_column_name,
             feature_names_column_name=feature_names_column_name,
         )
-        
+
         results = self.__async_sharded_request(
             adata=matrix,
             chunk_size=chunk_size,

--- a/cellarium/cas/exceptions.py
+++ b/cellarium/cas/exceptions.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 class CASBaseError(Exception):
@@ -37,6 +38,8 @@ class HTTPClientError(HTTPError):
 class DataValidationError(CASBaseError):
     missing_features: int
     extra_features: int
+    incompatible_x_type: Optional[str]
+    incompatible_total_mrna_umis_type: Optional[str]
 
 
 class QuotaExceededError(CASBaseError):

--- a/cellarium/cas/exceptions.py
+++ b/cellarium/cas/exceptions.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional
 
 
 class CASBaseError(Exception):
@@ -38,8 +37,6 @@ class HTTPClientError(HTTPError):
 class DataValidationError(CASBaseError):
     missing_features: int
     extra_features: int
-    incompatible_x_type: Optional[str]
-    incompatible_total_mrna_umis_type: Optional[str]
 
 
 class QuotaExceededError(CASBaseError):

--- a/cellarium/cas/preprocessing/__init__.py
+++ b/cellarium/cas/preprocessing/__init__.py
@@ -1,4 +1,4 @@
-from .sanitizer import sanitize  # noqa
+from .sanitizer import pre_sanitize, sanitize  # noqa
 from .validator import validate  # noqa
 
 __all__ = ["sanitize", "validate"]

--- a/cellarium/cas/preprocessing/callbacks.py
+++ b/cellarium/cas/preprocessing/callbacks.py
@@ -8,6 +8,23 @@ from cellarium.cas import constants
 TOTAL_MRNA_UMIS_COLUMN_NAME = "total_mrna_umis"
 
 
+def ensure_matrix_is_float32(adata: anndata.AnnData, count_matrix_input: constants.CountMatrixInput) -> None:
+    """
+    Ensure that the count matrix in the AnnData object is of type float32. If it is not, the function will convert it
+    to float32.
+
+    :param adata: The annotated data matrix to ensure the count matrix is of type float32.
+    :param count_matrix_input: Where to obtain a feature expression count matrix from. Choice of: 'X', 'raw.X'
+
+    :return: A new AnnData object with the same data as ``adata`` but with the count matrix converted to float32.
+    """
+
+    if count_matrix_input == constants.CountMatrixInput.X and adata.X.dtype != np.float32:
+        adata.X = adata.X.astype(np.float32)
+    elif count_matrix_input == constants.CountMatrixInput.RAW_X and adata.raw.X.dtype != np.float32:
+        adata.raw.X = adata.raw.X.astype(np.float32)
+
+
 def calculate_total_mrna_umis(adata: anndata.AnnData, count_matrix_input: constants.CountMatrixInput) -> None:
     """
     Calculate the total mRNA UMIs (Unique Molecular Identifiers) for each observation in the AnnData object and add them
@@ -36,6 +53,7 @@ def calculate_total_mrna_umis(adata: anndata.AnnData, count_matrix_input: consta
 
 
 _PRE_SANITIZE_CALLBACKS: t.List[t.Callable[[anndata.AnnData, constants.CountMatrixInput], None]] = [
+    ensure_matrix_is_float32,
     calculate_total_mrna_umis,
 ]
 

--- a/cellarium/cas/preprocessing/sanitizer.py
+++ b/cellarium/cas/preprocessing/sanitizer.py
@@ -86,9 +86,9 @@ def sanitize(
     # We have to do this before everything else because some of the following steps derive values
     # from the matrix, and those will cause things to break if they're the wrong type
     if count_matrix_input == constants.CountMatrixInput.X and adata.X.dtype != np.float32:
-        adata.X = adata.X.astype(np.float32, "same_kind")
+        adata.X = adata.X.astype(np.float32)
     elif count_matrix_input == constants.CountMatrixInput.RAW_X and adata.raw.X.dtype != np.float32:
-        adata.raw.X = adata.raw.X.astype(np.float32, "same_kind")
+        adata.raw.X = adata.raw.X.astype(np.float32)
 
     callbacks.pre_sanitize_callback(adata=adata, count_matrix_input=count_matrix_input)
 

--- a/cellarium/cas/preprocessing/validator.py
+++ b/cellarium/cas/preprocessing/validator.py
@@ -38,13 +38,8 @@ def validate(
     cas_feature_schema_set = set(cas_feature_schema_list)
     adata_feature_schema_set = set(adata_feature_schema_list)
 
-    incompatible_x_type: t.Optional[str] = None
-    if count_matrix_input == constants.CountMatrixInput.X:
-        if adata.X.dtype != np.float32:
-            incompatible_x_type = adata.X.dtype
-    else:
-        if adata.raw.X.dtype != np.float32:
-            incompatible_x_type = adata.raw.X.dtype
+    dtype_to_check = adata.X.dtype if count_matrix_input == constants.CountMatrixInput.X else adata.raw.X.dtype
+    incompatible_x_type: t.Optional[str] = None if dtype_to_check == np.float32 else dtype_to_check
 
     incompatible_total_mrna_umis_type: t.Optional[str] = None
     if "total_mrna_umis" in adata.obs and adata.obs["total_mrna_umis"].dtype != np.float32:

--- a/cellarium/cas/preprocessing/validator.py
+++ b/cellarium/cas/preprocessing/validator.py
@@ -45,11 +45,10 @@ def validate(
     else:
         if adata.raw.X.dtype != np.float32:
             incompatible_x_type = adata.raw.X.dtype
-    
+
     incompatible_total_mrna_umis_type: t.Optional[str] = None
     if "total_mrna_umis" in adata.obs and adata.obs["total_mrna_umis"].dtype != np.float32:
         incompatible_total_mrna_umis_type = adata.obs["total_mrna_umis"].dtype
-
 
     if (
         adata_feature_schema_list == cas_feature_schema_list
@@ -64,5 +63,8 @@ def validate(
     extra_features = len(adata_feature_schema_set - cas_feature_schema_set)
 
     raise exceptions.DataValidationError(
-        missing_features=missing_features, extra_features=extra_features, incompatible_x_type=incompatible_x_type, incompatible_total_mrna_umis_type=incompatible_total_mrna_umis_type
+        missing_features=missing_features,
+        extra_features=extra_features,
+        incompatible_x_type=incompatible_x_type,
+        incompatible_total_mrna_umis_type=incompatible_total_mrna_umis_type,
     )

--- a/cellarium/cas/preprocessing/validator.py
+++ b/cellarium/cas/preprocessing/validator.py
@@ -1,7 +1,5 @@
 import typing as t
 
-import numpy as np
-
 from cellarium.cas import constants, exceptions
 
 if t.TYPE_CHECKING:
@@ -38,17 +36,8 @@ def validate(
     cas_feature_schema_set = set(cas_feature_schema_list)
     adata_feature_schema_set = set(adata_feature_schema_list)
 
-    dtype_to_check = adata.X.dtype if count_matrix_input == constants.CountMatrixInput.X else adata.raw.X.dtype
-    incompatible_x_type: t.Optional[str] = None if dtype_to_check == np.float32 else dtype_to_check
-
-    incompatible_total_mrna_umis_type: t.Optional[str] = None
-    if "total_mrna_umis" in adata.obs and adata.obs["total_mrna_umis"].dtype != np.float32:
-        incompatible_total_mrna_umis_type = adata.obs["total_mrna_umis"].dtype
-
     if (
         adata_feature_schema_list == cas_feature_schema_list
-        and incompatible_x_type is None
-        and incompatible_total_mrna_umis_type is None
         # We want to be sure to sanitize if the count matrix is raw.X
         and count_matrix_input == constants.CountMatrixInput.X
     ):
@@ -60,6 +49,4 @@ def validate(
     raise exceptions.DataValidationError(
         missing_features=missing_features,
         extra_features=extra_features,
-        incompatible_x_type=incompatible_x_type,
-        incompatible_total_mrna_umis_type=incompatible_total_mrna_umis_type,
     )

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -113,7 +113,7 @@ class TestdataPreparation(unittest.TestCase):
         data_validation_error_was_raised = False
         number_of_missing_features = 0
         number_of_extra_features = 0
-        d = np_random_state.randint(0, 500, size=(self.INPUT_DATASET_LENGTH, len(adata_feature_schema_list)))
+        d = np_random_state.randn(self.INPUT_DATASET_LENGTH, len(adata_feature_schema_list)).astype(np.float32)
         adata = anndata.AnnData(
             X=sp.csr_matrix(d),
             obs=pd.DataFrame(index=np.arange(0, self.INPUT_DATASET_LENGTH)),
@@ -129,12 +129,16 @@ class TestdataPreparation(unittest.TestCase):
         except exceptions.DataValidationError as e:
             number_of_missing_features = e.missing_features
             number_of_extra_features = e.extra_features
+            incompatible_x_type = e.incompatible_x_type
+            incompatible_total_mrna_umis_type = e.incompatible_total_mrna_umis_type
             data_validation_error_was_raised = True
 
         self.assertTrue(
             data_validation_error_was_raised,
             msg="`DataValidationError should be raised`",
         )
+        self.assertIsNone(incompatible_x_type)
+        self.assertIsNone(incompatible_total_mrna_umis_type)
         self.assertEqual(
             number_of_missing_features,
             len(cas_feature_schema_list) - len(adata_feature_schema_list),
@@ -151,7 +155,7 @@ class TestdataPreparation(unittest.TestCase):
         data_validation_error_was_raised = False
         number_of_missing_features = 0
         number_of_extra_features = 0
-        d = np_random_state.randint(0, 500, size=(self.INPUT_DATASET_LENGTH, len(adata_feature_schema_list)))
+        d = np_random_state.randn(self.INPUT_DATASET_LENGTH, len(adata_feature_schema_list)).astype(np.float32)
         adata = anndata.AnnData(
             X=sp.csr_matrix(d),
             obs=pd.DataFrame(index=np.arange(0, self.INPUT_DATASET_LENGTH)),
@@ -167,12 +171,16 @@ class TestdataPreparation(unittest.TestCase):
         except exceptions.DataValidationError as e:
             number_of_missing_features = e.missing_features
             number_of_extra_features = e.extra_features
+            incompatible_x_type = e.incompatible_x_type
+            incompatible_total_mrna_umis_type = e.incompatible_total_mrna_umis_type
             data_validation_error_was_raised = True
 
         self.assertTrue(
             data_validation_error_was_raised,
             msg="`DataValidationError should be raised`",
         )
+        self.assertIsNone(incompatible_x_type)
+        self.assertIsNone(incompatible_total_mrna_umis_type)
         self.assertEqual(
             number_of_missing_features,
             0,
@@ -193,7 +201,7 @@ class TestdataPreparation(unittest.TestCase):
         data_validation_error_was_raised = False
         number_of_missing_features = 0
         number_of_extra_features = 0
-        d = np_random_state.randint(0, 500, size=(self.INPUT_DATASET_LENGTH, len(adata_feature_schema_list)))
+        d = np_random_state.randn(self.INPUT_DATASET_LENGTH, len(adata_feature_schema_list)).astype(np.float32)
         adata = anndata.AnnData(
             X=sp.csr_matrix(d),
             obs=pd.DataFrame(index=np.arange(0, self.INPUT_DATASET_LENGTH)),
@@ -209,6 +217,8 @@ class TestdataPreparation(unittest.TestCase):
         except exceptions.DataValidationError as e:
             number_of_missing_features = e.missing_features
             number_of_extra_features = e.extra_features
+            incompatible_x_type = e.incompatible_x_type
+            incompatible_total_mrna_umis_type = e.incompatible_total_mrna_umis_type
             data_validation_error_was_raised = True
 
         missing_features = len(set(cas_feature_schema_list) - set(adata_feature_schema_list))
@@ -217,6 +227,8 @@ class TestdataPreparation(unittest.TestCase):
             data_validation_error_was_raised,
             msg="`DataValidationError should be raised`",
         )
+        self.assertIsNone(incompatible_x_type)
+        self.assertIsNone(incompatible_total_mrna_umis_type)
         self.assertEqual(number_of_missing_features, missing_features)
         self.assertEqual(number_of_extra_features, extra_features)
 
@@ -226,7 +238,7 @@ class TestdataPreparation(unittest.TestCase):
         data_validation_error_was_raised = False
         number_of_missing_features = 0
         number_of_extra_features = 0
-        d = np_random_state.randint(0, 500, size=(self.INPUT_DATASET_LENGTH, len(adata_feature_schema_list)))
+        d = np_random_state.randn(self.INPUT_DATASET_LENGTH, len(adata_feature_schema_list)).astype(np.float32)
         adata = anndata.AnnData(
             X=sp.csr_matrix(d),
             obs=pd.DataFrame(index=np.arange(0, self.INPUT_DATASET_LENGTH)),
@@ -242,24 +254,134 @@ class TestdataPreparation(unittest.TestCase):
         except exceptions.DataValidationError as e:
             number_of_missing_features = e.missing_features
             number_of_extra_features = e.extra_features
+            incompatible_x_type = e.incompatible_x_type
+            incompatible_total_mrna_umis_type = e.incompatible_total_mrna_umis_type
             data_validation_error_was_raised = True
 
         self.assertTrue(
             data_validation_error_was_raised,
             msg="`DataValidationError should be raised`",
         )
+        self.assertIsNone(incompatible_x_type)
+        self.assertIsNone(incompatible_total_mrna_umis_type)
+        self.assertEqual(number_of_missing_features, 0)
+        self.assertEqual(number_of_extra_features, 0)
+
+    def test_matrix_is_float64(self):
+        cas_feature_schema_list = self.get_feature_schema()
+        data_validation_error_was_raised = False
+        number_of_missing_features = 0
+        number_of_extra_features = 0
+        d = np_random_state.randn(self.INPUT_DATASET_LENGTH, len(cas_feature_schema_list)).astype(np.float32)
+        adata = anndata.AnnData(
+            X=sp.csr_matrix(d),
+            obs=pd.DataFrame(index=np.arange(0, self.INPUT_DATASET_LENGTH)),
+            var=pd.DataFrame(index=cas_feature_schema_list),
+        )
+        adata.X = adata.X.astype(np.float64)
+        try:
+            preprocessing.validate(
+                adata=adata,
+                cas_feature_schema_list=cas_feature_schema_list,
+                feature_ids_column_name="index",
+                count_matrix_input=constants.CountMatrixInput.X,
+            )
+        except exceptions.DataValidationError as e:
+            number_of_missing_features = e.missing_features
+            number_of_extra_features = e.extra_features
+            incompatible_x_type = e.incompatible_x_type
+            incompatible_total_mrna_umis_type = e.incompatible_total_mrna_umis_type
+            data_validation_error_was_raised = True
+
+        self.assertTrue(
+            data_validation_error_was_raised,
+            msg="`DataValidationError should be raised`",
+        )
+        self.assertEqual(incompatible_x_type, np.float64)
+        self.assertIsNone(incompatible_total_mrna_umis_type)
+        self.assertEqual(number_of_missing_features, 0)
+        self.assertEqual(number_of_extra_features, 0)
+    
+    def test_matrix_is_int(self):
+        cas_feature_schema_list = self.get_feature_schema()
+        data_validation_error_was_raised = False
+        number_of_missing_features = 0
+        number_of_extra_features = 0
+        d = np_random_state.randn(self.INPUT_DATASET_LENGTH, len(cas_feature_schema_list)).astype(np.float32)
+        adata = anndata.AnnData(
+            X=sp.csr_matrix(d),
+            obs=pd.DataFrame(index=np.arange(0, self.INPUT_DATASET_LENGTH)),
+            var=pd.DataFrame(index=cas_feature_schema_list),
+        )
+        adata.X = adata.X.astype(np.int32)
+        try:
+            preprocessing.validate(
+                adata=adata,
+                cas_feature_schema_list=cas_feature_schema_list,
+                feature_ids_column_name="index",
+                count_matrix_input=constants.CountMatrixInput.X,
+            )
+        except exceptions.DataValidationError as e:
+            number_of_missing_features = e.missing_features
+            number_of_extra_features = e.extra_features
+            incompatible_x_type = e.incompatible_x_type
+            incompatible_total_mrna_umis_type = e.incompatible_total_mrna_umis_type
+            data_validation_error_was_raised = True
+
+        self.assertTrue(
+            data_validation_error_was_raised,
+            msg="`DataValidationError should be raised`",
+        )
+        self.assertEqual(incompatible_x_type, np.int32)
+        self.assertIsNone(incompatible_total_mrna_umis_type)
+        self.assertEqual(number_of_missing_features, 0)
+        self.assertEqual(number_of_extra_features, 0)
+
+    def test_total_mrna_umis_is_float64(self):
+        cas_feature_schema_list = self.get_feature_schema()
+        data_validation_error_was_raised = False
+        number_of_missing_features = 0
+        number_of_extra_features = 0
+        d = np_random_state.randn(self.INPUT_DATASET_LENGTH, len(cas_feature_schema_list)).astype(np.float32)
+        adata = anndata.AnnData(
+            X=sp.csr_matrix(d),
+            obs=pd.DataFrame(index=np.arange(0, self.INPUT_DATASET_LENGTH)),
+            var=pd.DataFrame(index=cas_feature_schema_list),
+        )
+        adata.obs["total_mrna_umis"] = np.zeros(self.INPUT_DATASET_LENGTH).astype(np.float64)
+        try:
+            preprocessing.validate(
+                adata=adata,
+                cas_feature_schema_list=cas_feature_schema_list,
+                feature_ids_column_name="index",
+                count_matrix_input=constants.CountMatrixInput.X,
+            )
+        except exceptions.DataValidationError as e:
+            number_of_missing_features = e.missing_features
+            number_of_extra_features = e.extra_features
+            incompatible_x_type = e.incompatible_x_type
+            incompatible_total_mrna_umis_type = e.incompatible_total_mrna_umis_type
+            data_validation_error_was_raised = True
+
+        self.assertTrue(
+            data_validation_error_was_raised,
+            msg="`DataValidationError should be raised`",
+        )
+        self.assertIsNone(incompatible_x_type)
+        self.assertEqual(incompatible_total_mrna_umis_type, np.float64)
         self.assertEqual(number_of_missing_features, 0)
         self.assertEqual(number_of_extra_features, 0)
 
     def test_data_sanitizing(self):
         cas_feature_schema_list = self.get_feature_schema()
         adata_feature_schema_list = self.get_schema_that_has_missing_and_extra()
-        d = np_random_state.randint(0, 500, size=(self.INPUT_DATASET_LENGTH, len(adata_feature_schema_list)))
+        d = np_random_state.randn(self.INPUT_DATASET_LENGTH, len(adata_feature_schema_list)).astype(np.float32)
         adata = anndata.AnnData(
             X=sp.csr_matrix(d),
             obs=pd.DataFrame(index=np.arange(0, self.INPUT_DATASET_LENGTH)),
             var=pd.DataFrame(index=adata_feature_schema_list),
         )
+        adata.X = adata.X.astype(np.float64)
         adata_new = preprocessing.sanitize(
             adata=adata,
             cas_feature_schema_list=cas_feature_schema_list,
@@ -269,6 +391,8 @@ class TestdataPreparation(unittest.TestCase):
         intersect_features = list(set(cas_feature_schema_list).intersection(set(adata_feature_schema_list)))
         new_matrix_didnt_lose_values = (adata_new[:, intersect_features].X != adata[:, intersect_features].X).sum() == 0
         self.assertTrue(new_matrix_didnt_lose_values)
+        self.assertEqual(adata_new.X.dtype, np.float32)
+        self.assertEqual(adata_new.obs["total_mrna_umis"].dtype, np.float32)
 
 
 def main():

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -301,7 +301,7 @@ class TestdataPreparation(unittest.TestCase):
         self.assertIsNone(incompatible_total_mrna_umis_type)
         self.assertEqual(number_of_missing_features, 0)
         self.assertEqual(number_of_extra_features, 0)
-    
+
     def test_matrix_is_int(self):
         cas_feature_schema_list = self.get_feature_schema()
         data_validation_error_was_raised = False

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -124,6 +124,7 @@ class TestdataPreparation(unittest.TestCase):
                 adata=adata,
                 cas_feature_schema_list=cas_feature_schema_list,
                 feature_ids_column_name="index",
+                count_matrix_input=constants.CountMatrixInput.X,
             )
         except exceptions.DataValidationError as e:
             number_of_missing_features = e.missing_features
@@ -161,6 +162,7 @@ class TestdataPreparation(unittest.TestCase):
                 adata=adata,
                 cas_feature_schema_list=cas_feature_schema_list,
                 feature_ids_column_name="index",
+                count_matrix_input=constants.CountMatrixInput.X,
             )
         except exceptions.DataValidationError as e:
             number_of_missing_features = e.missing_features
@@ -202,6 +204,7 @@ class TestdataPreparation(unittest.TestCase):
                 adata=adata,
                 cas_feature_schema_list=cas_feature_schema_list,
                 feature_ids_column_name="index",
+                count_matrix_input=constants.CountMatrixInput.X,
             )
         except exceptions.DataValidationError as e:
             number_of_missing_features = e.missing_features
@@ -234,6 +237,7 @@ class TestdataPreparation(unittest.TestCase):
                 adata=adata,
                 cas_feature_schema_list=cas_feature_schema_list,
                 feature_ids_column_name="index",
+                count_matrix_input=constants.CountMatrixInput.X,
             )
         except exceptions.DataValidationError as e:
             number_of_missing_features = e.missing_features

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -129,16 +129,12 @@ class TestdataPreparation(unittest.TestCase):
         except exceptions.DataValidationError as e:
             number_of_missing_features = e.missing_features
             number_of_extra_features = e.extra_features
-            incompatible_x_type = e.incompatible_x_type
-            incompatible_total_mrna_umis_type = e.incompatible_total_mrna_umis_type
             data_validation_error_was_raised = True
 
         self.assertTrue(
             data_validation_error_was_raised,
             msg="`DataValidationError should be raised`",
         )
-        self.assertIsNone(incompatible_x_type)
-        self.assertIsNone(incompatible_total_mrna_umis_type)
         self.assertEqual(
             number_of_missing_features,
             len(cas_feature_schema_list) - len(adata_feature_schema_list),
@@ -171,16 +167,12 @@ class TestdataPreparation(unittest.TestCase):
         except exceptions.DataValidationError as e:
             number_of_missing_features = e.missing_features
             number_of_extra_features = e.extra_features
-            incompatible_x_type = e.incompatible_x_type
-            incompatible_total_mrna_umis_type = e.incompatible_total_mrna_umis_type
             data_validation_error_was_raised = True
 
         self.assertTrue(
             data_validation_error_was_raised,
             msg="`DataValidationError should be raised`",
         )
-        self.assertIsNone(incompatible_x_type)
-        self.assertIsNone(incompatible_total_mrna_umis_type)
         self.assertEqual(
             number_of_missing_features,
             0,
@@ -217,8 +209,6 @@ class TestdataPreparation(unittest.TestCase):
         except exceptions.DataValidationError as e:
             number_of_missing_features = e.missing_features
             number_of_extra_features = e.extra_features
-            incompatible_x_type = e.incompatible_x_type
-            incompatible_total_mrna_umis_type = e.incompatible_total_mrna_umis_type
             data_validation_error_was_raised = True
 
         missing_features = len(set(cas_feature_schema_list) - set(adata_feature_schema_list))
@@ -227,8 +217,6 @@ class TestdataPreparation(unittest.TestCase):
             data_validation_error_was_raised,
             msg="`DataValidationError should be raised`",
         )
-        self.assertIsNone(incompatible_x_type)
-        self.assertIsNone(incompatible_total_mrna_umis_type)
         self.assertEqual(number_of_missing_features, missing_features)
         self.assertEqual(number_of_extra_features, extra_features)
 
@@ -254,121 +242,12 @@ class TestdataPreparation(unittest.TestCase):
         except exceptions.DataValidationError as e:
             number_of_missing_features = e.missing_features
             number_of_extra_features = e.extra_features
-            incompatible_x_type = e.incompatible_x_type
-            incompatible_total_mrna_umis_type = e.incompatible_total_mrna_umis_type
             data_validation_error_was_raised = True
 
         self.assertTrue(
             data_validation_error_was_raised,
             msg="`DataValidationError should be raised`",
         )
-        self.assertIsNone(incompatible_x_type)
-        self.assertIsNone(incompatible_total_mrna_umis_type)
-        self.assertEqual(number_of_missing_features, 0)
-        self.assertEqual(number_of_extra_features, 0)
-
-    def test_matrix_is_float64(self):
-        cas_feature_schema_list = self.get_feature_schema()
-        data_validation_error_was_raised = False
-        number_of_missing_features = 0
-        number_of_extra_features = 0
-        d = np_random_state.randn(self.INPUT_DATASET_LENGTH, len(cas_feature_schema_list)).astype(np.float32)
-        adata = anndata.AnnData(
-            X=sp.csr_matrix(d),
-            obs=pd.DataFrame(index=np.arange(0, self.INPUT_DATASET_LENGTH)),
-            var=pd.DataFrame(index=cas_feature_schema_list),
-        )
-        adata.X = adata.X.astype(np.float64)
-        try:
-            preprocessing.validate(
-                adata=adata,
-                cas_feature_schema_list=cas_feature_schema_list,
-                feature_ids_column_name="index",
-                count_matrix_input=constants.CountMatrixInput.X,
-            )
-        except exceptions.DataValidationError as e:
-            number_of_missing_features = e.missing_features
-            number_of_extra_features = e.extra_features
-            incompatible_x_type = e.incompatible_x_type
-            incompatible_total_mrna_umis_type = e.incompatible_total_mrna_umis_type
-            data_validation_error_was_raised = True
-
-        self.assertTrue(
-            data_validation_error_was_raised,
-            msg="`DataValidationError should be raised`",
-        )
-        self.assertEqual(incompatible_x_type, np.float64)
-        self.assertIsNone(incompatible_total_mrna_umis_type)
-        self.assertEqual(number_of_missing_features, 0)
-        self.assertEqual(number_of_extra_features, 0)
-
-    def test_matrix_is_int(self):
-        cas_feature_schema_list = self.get_feature_schema()
-        data_validation_error_was_raised = False
-        number_of_missing_features = 0
-        number_of_extra_features = 0
-        d = np_random_state.randn(self.INPUT_DATASET_LENGTH, len(cas_feature_schema_list)).astype(np.float32)
-        adata = anndata.AnnData(
-            X=sp.csr_matrix(d),
-            obs=pd.DataFrame(index=np.arange(0, self.INPUT_DATASET_LENGTH)),
-            var=pd.DataFrame(index=cas_feature_schema_list),
-        )
-        adata.X = adata.X.astype(np.int32)
-        try:
-            preprocessing.validate(
-                adata=adata,
-                cas_feature_schema_list=cas_feature_schema_list,
-                feature_ids_column_name="index",
-                count_matrix_input=constants.CountMatrixInput.X,
-            )
-        except exceptions.DataValidationError as e:
-            number_of_missing_features = e.missing_features
-            number_of_extra_features = e.extra_features
-            incompatible_x_type = e.incompatible_x_type
-            incompatible_total_mrna_umis_type = e.incompatible_total_mrna_umis_type
-            data_validation_error_was_raised = True
-
-        self.assertTrue(
-            data_validation_error_was_raised,
-            msg="`DataValidationError should be raised`",
-        )
-        self.assertEqual(incompatible_x_type, np.int32)
-        self.assertIsNone(incompatible_total_mrna_umis_type)
-        self.assertEqual(number_of_missing_features, 0)
-        self.assertEqual(number_of_extra_features, 0)
-
-    def test_total_mrna_umis_is_float64(self):
-        cas_feature_schema_list = self.get_feature_schema()
-        data_validation_error_was_raised = False
-        number_of_missing_features = 0
-        number_of_extra_features = 0
-        d = np_random_state.randn(self.INPUT_DATASET_LENGTH, len(cas_feature_schema_list)).astype(np.float32)
-        adata = anndata.AnnData(
-            X=sp.csr_matrix(d),
-            obs=pd.DataFrame(index=np.arange(0, self.INPUT_DATASET_LENGTH)),
-            var=pd.DataFrame(index=cas_feature_schema_list),
-        )
-        adata.obs["total_mrna_umis"] = np.zeros(self.INPUT_DATASET_LENGTH).astype(np.float64)
-        try:
-            preprocessing.validate(
-                adata=adata,
-                cas_feature_schema_list=cas_feature_schema_list,
-                feature_ids_column_name="index",
-                count_matrix_input=constants.CountMatrixInput.X,
-            )
-        except exceptions.DataValidationError as e:
-            number_of_missing_features = e.missing_features
-            number_of_extra_features = e.extra_features
-            incompatible_x_type = e.incompatible_x_type
-            incompatible_total_mrna_umis_type = e.incompatible_total_mrna_umis_type
-            data_validation_error_was_raised = True
-
-        self.assertTrue(
-            data_validation_error_was_raised,
-            msg="`DataValidationError should be raised`",
-        )
-        self.assertIsNone(incompatible_x_type)
-        self.assertEqual(incompatible_total_mrna_umis_type, np.float64)
         self.assertEqual(number_of_missing_features, 0)
         self.assertEqual(number_of_extra_features, 0)
 
@@ -381,7 +260,6 @@ class TestdataPreparation(unittest.TestCase):
             obs=pd.DataFrame(index=np.arange(0, self.INPUT_DATASET_LENGTH)),
             var=pd.DataFrame(index=adata_feature_schema_list),
         )
-        adata.X = adata.X.astype(np.float64)
         adata_new = preprocessing.sanitize(
             adata=adata,
             cas_feature_schema_list=cas_feature_schema_list,
@@ -391,8 +269,6 @@ class TestdataPreparation(unittest.TestCase):
         intersect_features = list(set(cas_feature_schema_list).intersection(set(adata_feature_schema_list)))
         new_matrix_didnt_lose_values = (adata_new[:, intersect_features].X != adata[:, intersect_features].X).sum() == 0
         self.assertTrue(new_matrix_didnt_lose_values)
-        self.assertEqual(adata_new.X.dtype, np.float32)
-        self.assertEqual(adata_new.obs["total_mrna_umis"].dtype, np.float32)
 
 
 def main():

--- a/tests/unit/test_preprocessing_callbacks.py
+++ b/tests/unit/test_preprocessing_callbacks.py
@@ -5,6 +5,8 @@ import pandas as pd
 from cellarium.cas import constants
 from cellarium.cas.preprocessing import callbacks
 
+np_random_state = np.random.RandomState(0)
+
 
 def test_calculate_total_mrna_umis_X():
     """
@@ -78,3 +80,30 @@ def test_calculate_total_mrna_umis_raw_X():
         [3, 1, 3],
         err_msg="Total mRNA UMI calculations are incorrect",
     )
+
+
+def test_ensure_matrix_is_float32_X():
+    """
+    Test :func:`preprocessing.callbacks.ensure_matrix_is_float32` function when X is not of type float32.
+    """
+    X = np_random_state.randn(5, 5).astype(np.float64)
+    obs = pd.DataFrame(index=["cell1", "cell2", "cell3", "cell4", "cell5"])
+    adata = anndata.AnnData(X=X, obs=obs)
+
+    callbacks.ensure_matrix_is_float32(adata, count_matrix_input=constants.CountMatrixInput.X)
+
+    assert adata.X.dtype == np.float32, "X matrix is not of type float32"
+
+
+def test_ensure_matrix_is_float32_raw_X():
+    """
+    Test :func:`preprocessing.callbacks.ensure_matrix_is_float32` function when X is not of type float32.
+    """
+    raw_X = np_random_state.randn(5, 5).astype(np.int32)
+    obs = pd.DataFrame(index=["cell1", "cell2", "cell3", "cell4", "cell5"])
+    adata = anndata.AnnData(X=raw_X, obs=obs)
+    adata.raw = adata
+
+    callbacks.ensure_matrix_is_float32(adata, count_matrix_input=constants.CountMatrixInput.RAW_X)
+
+    assert adata.raw.X.dtype == np.float32, "raw X matrix is not of type float32"


### PR DESCRIPTION
Cellarium-ai (and I think also anndata, technically) only support float32 matrices for the input anndata files, and this is causing errors when users try to submit anndata files with other types (although I'm not 100% sure that's even fully supported by anndata).  This change adds steps in validation to detect the type mismatch in the two places it can cause issues, and sanitization to convert the data to float32.