### PR TITLE
CAS-65 Build docs locally

### DIFF
--- a/.github/actions/unit-tests/action.yaml
+++ b/.github/actions/unit-tests/action.yaml
@@ -23,8 +23,21 @@ runs:
       run: tox -e lint
       shell: bash
 
+    - name: Should run doc build
+      run: |
+        import os
+        from packaging.version import Version
+        with open(os.getenv("GITHUB_ENV"), "a") as file_env:
+          python_version = Version("${{ inputs.python-version }}")
+          min_python_version = Version("3.10")
+          if python_version < min_python_version:
+            file_env.write(f"DO_DOC_BUILD=false\n")
+          else:
+            file_env.write(f"DO_DOC_BUILD=true\n")
+      shell: python
     - name: Run doc build
       # Run tox using the version of Python in `PATH`
+      if: ${{ env.DO_DOC_BUILD == 'true' }}
       run: tox -e docs
       shell: bash
 

--- a/.github/actions/unit-tests/action.yaml
+++ b/.github/actions/unit-tests/action.yaml
@@ -1,4 +1,4 @@
-name: Tox unit tests and linting
+name: Unit tests and linting
 description: Run unit tests in different python environments
 inputs:
   python-version:
@@ -18,12 +18,17 @@ runs:
         pip install -r requirements/dev.txt
       shell: bash
 
-    - name: Run Tox lint commands
+    - name: Run linting
       # Run tox using the version of Python in `PATH`
       run: tox -e lint
       shell: bash
 
-    - name: Run Pytest through Tox
+    - name: Run doc build
+      # Run tox using the version of Python in `PATH`
+      run: tox -e docs
+      shell: bash
+
+    - name: Run unit tests
       # Run tox using the version of Python in `PATH`
       run: tox -e unit
       shell: bash

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -83,12 +83,12 @@ Added
 
 Added
 ~~~~~
-- Add :meth:`annotate_matrix_cell_type_summary_statistics_strategy` method to :class:`CASClient`
-- Add :meth:`annotate_matrix_cell_type_ontology_aware_strategy` method to :class:`CASClient`
+- Add :meth:`cellarium.cas.client.CASClient.annotate_matrix_cell_type_summary_statistics_strategy` method to :class:`cellarium.cas.client.CASClient`
+- Add :meth:`cellarium.cas.client.CASClient.annotate_matrix_cell_type_ontology_aware_strategy` method to :class:`cellarium.cas.client.CASClient`
 
 Changed
 ~~~~~~~
-- Deprecate :meth:`annotate_anndata`, :meth:`annotate_anndata_file`, :meth:`annotate_10x_h5_file`, :meth:`search_anndata`, and :meth:`search_10x_h5_file`,  methods in :class:`CASClient`
+- Deprecate :meth:`cellarium.cas.client.CASClient.annotate_anndata`, :meth:`cellarium.cas.client.CASClient.annotate_anndata_file`, :meth:`cellarium.cas.client.CASClient.annotate_10x_h5_file`, :meth:`cellarium.cas.client.CASClient.search_anndata`, and :meth:`cellarium.cas.client.CASClient.search_10x_h5_file`,  methods in :class:`cellarium.cas.client.CASClient`
 
 File Structure Changes
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -121,8 +121,8 @@ Added
 - Include kNN search method (#49)
 - Include get cells by IDs method (#49)
 - Include helper methods for visualization and demo
-- Add model name validation method to :class:`clients.CASClient`
-- Add sync POST method (using requests) to :class:`services.CASAPIService`
+- Add model name validation method to :class:`cellarium.cas.client.CASClient`
+- Add sync POST method (using requests) to CASAPIService
 - Add `CHANGELOG.rst` file
 - Add settings module that chooses the correct settings file based on the environment according to current git version. Since now package will use development settings if it's tagged as a pre-release (alpha, beta, or release candidate (rc)), and production settings otherwise.
 - Add version determination based on git tags
@@ -130,10 +130,10 @@ Added
 
 Changed
 ~~~~~~~
-- Reorganize :class:`CASClient` methods: factor out sharding logic
+- Reorganize :class:`cellarium.cas.client.CASClient` methods: factor out sharding logic
 - Update `MAX_NUM_REQUESTS_AT_A_TIME` to 25
-- Update default `chunk_size` in :meth:`annotate` methods to 1000
-- Make :meth:`__validate_and_sanitize_input_data` method public (now it's a :meth:`validate_and_sanitize_input_data`) in CASClient
+- Update default `chunk_size` in :meth:`cellarium.cas.client.CASClient.annotate_anndata` methods to 1000
+- Make `__validate_and_sanitize_input_data` method public (now it is :meth:`cellarium.cas.client.CASClient.validate_and_sanitize_input_data`) in :class:`cellarium.cas.client.CASClient`
 - Update backend API url to point to the new API endpoints depending on the environment
 - Update `pyproject.toml` file to include scanpy optional dependencies
 - Restructure data_preparation into a module

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,15 @@ All notable changes to Cellarium CAS client will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+<pre-version> - <pre-date>
+--------------------------
+
+Changed
+~~~~~~~
+- Added ability to render documentation locally
+- PR tests will now fail when doc is invalid
+- Fixed bugs documentation navigation
+
 1.4.12 - 2024-08-01
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,11 +49,11 @@ Added
 
 Changed
 ~~~~~~~
-- Renamed `data_preparation`` to `preprocessing``
-- Moved all preprocessing-related code to `preprocessing`` submodule
-- Added a `postprocessing`` submodule
-- Added a `visualization`` submodule
-- Renamed `scanpy` optional dependencies to `vis` (for all visualization-related dependencies)
+- Renamed ``data_preparation`` to ``preprocessing```
+- Moved all preprocessing-related code to ``preprocessing`` submodule
+- Added a ``postprocessing`` submodule
+- Added a ``visualization`` submodule
+- Renamed ``scanpy`` optional dependencies to ``vis`` (for all visualization-related dependencies)
 
 
 1.4.8 - 2024-07-22
@@ -92,12 +92,12 @@ Added
 
 Added
 ~~~~~
-- Add :meth:`cellarium.cas.client.CASClient.annotate_matrix_cell_type_summary_statistics_strategy` method to :class:`cellarium.cas.client.CASClient`
-- Add :meth:`cellarium.cas.client.CASClient.annotate_matrix_cell_type_ontology_aware_strategy` method to :class:`cellarium.cas.client.CASClient`
+- Add :meth:`~.CASClient.annotate_matrix_cell_type_summary_statistics_strategy` method to :class:`~.CASClient`
+- Add :meth:`~.CASClient.annotate_matrix_cell_type_ontology_aware_strategy` method to :class:`~.CASClient`
 
 Changed
 ~~~~~~~
-- Deprecate :meth:`cellarium.cas.client.CASClient.annotate_anndata`, :meth:`cellarium.cas.client.CASClient.annotate_anndata_file`, :meth:`cellarium.cas.client.CASClient.annotate_10x_h5_file`, :meth:`cellarium.cas.client.CASClient.search_anndata`, and :meth:`cellarium.cas.client.CASClient.search_10x_h5_file`,  methods in :class:`cellarium.cas.client.CASClient`
+- Deprecate :meth:`~.CASClient.annotate_anndata`, :meth:`~.CASClient.annotate_anndata_file`, :meth:`~.CASClient.annotate_10x_h5_file`, :meth:`~.CASClient.search_anndata`, and :meth:`~.CASClient.search_10x_h5_file`,  methods in :class:`~.CASClient`
 
 File Structure Changes
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -130,21 +130,21 @@ Added
 - Include kNN search method (#49)
 - Include get cells by IDs method (#49)
 - Include helper methods for visualization and demo
-- Add model name validation method to :class:`cellarium.cas.client.CASClient`
+- Add model name validation method to :class:`~.CASClient`
 - Add sync POST method (using requests) to CASAPIService
-- Add `CHANGELOG.rst` file
+- Add ``CHANGELOG.rst`` file
 - Add settings module that chooses the correct settings file based on the environment according to current git version. Since now package will use development settings if it's tagged as a pre-release (alpha, beta, or release candidate (rc)), and production settings otherwise.
 - Add version determination based on git tags
 - Add callback methods to data_preparation module. Include total total_mrna_umis calculation as a callback before data sanitization
 
 Changed
 ~~~~~~~
-- Reorganize :class:`cellarium.cas.client.CASClient` methods: factor out sharding logic
-- Update `MAX_NUM_REQUESTS_AT_A_TIME` to 25
-- Update default `chunk_size` in :meth:`cellarium.cas.client.CASClient.annotate_anndata` methods to 1000
-- Make `__validate_and_sanitize_input_data` method public (now it is :meth:`cellarium.cas.client.CASClient.validate_and_sanitize_input_data`) in :class:`cellarium.cas.client.CASClient`
+- Reorganize :class:`~.CASClient` methods: factor out sharding logic
+- Update ``MAX_NUM_REQUESTS_AT_A_TIME`` to 25
+- Update default ``chunk_size`` in :meth:`~.CASClient.annotate_anndata` methods to 1000
+- Make ``__validate_and_sanitize_input_data`` method public (now it is :meth:`~.CASClient.validate_and_sanitize_input_data`) in :class:`~.CASClient`
 - Update backend API url to point to the new API endpoints depending on the environment
-- Update `pyproject.toml` file to include scanpy optional dependencies
+- Update ``pyproject.toml`` file to include scanpy optional dependencies
 - Restructure data_preparation into a module
 
 Removed
@@ -153,15 +153,15 @@ Removed
 
 File Structure Changes
 ~~~~~~~~~~~~~~~~~~~~~~
-- Add `CHANGELOG.rst` file
-- Add `requirements/scanpy.txt` file (optional requirements for scanpy related demos)
-- Add `cellarium/cas/scanpy_utils.py` (Not necessary for the client methods, but useful for the demo)
-- Add `cellarium/cas/settings` directory, including `__init__.py`, `base.py`, `development.py`, and `production.py` files
+- Add ``CHANGELOG.rst`` file
+- Add ``requirements/scanpy.txt`` file (optional requirements for scanpy related demos)
+- Add ``cellarium/cas/scanpy_utils.py`` (Not necessary for the client methods, but useful for the demo)
+- Add ``cellarium/cas/settings`` directory, including ``__init__.py``, ``base.py``, ``development.py``, and ``production.py`` files
 - Add cas/version.py file
-- Add `cellarium/cas/data_preparation` directory, including `__init__.py`, `callbacks.py`, `sanitizer.py` and `validator.py` files
-- Add `tests/unit/test_data_preparation_callbacks.py` file
-- Add `cellarium/cas/constants.py` file
-- Remove `.github/actions/docs` folder (docs are now hosted on readthedocs)
+- Add ``cellarium/cas/data_preparation`` directory, including ``__init__.py``, ``callbacks.py``, ``sanitizer.py`` and ``validator.py``` files
+- Add ``tests/unit/test_data_preparation_callbacks.py`` file
+- Add ``cellarium/cas/constants.py`` file
+- Remove ``.github/actions/docs`` folder (docs are now hosted on readthedocs)
 
 Notes
 ~~~~~

--- a/cellarium/cas/client.py
+++ b/cellarium/cas/client.py
@@ -152,7 +152,7 @@ class CASClient:
             `Allowed Values:` Model name from the :attr:`allowed_models_list` list keyword, which refers to the
             default selected model in the Cellarium backend. |br|
         :param count_matrix_name:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values:` Choice of either ``"X"``  or ``"raw.X"`` in order to use ``adata.X`` or ``adata.raw.X``|br|
+            `Allowed Values:` Choice of either ``"X"``  or ``"raw.X"`` in order to use ``adata.X`` or ``adata.raw.X`` |br|
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
             column. |br|

--- a/cellarium/cas/client.py
+++ b/cellarium/cas/client.py
@@ -511,8 +511,7 @@ class CASClient:
             keyword, which refers to the default selected model in the Cellarium backend. |br|
             `Default:` ``"default"``
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
-            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
+            `Allowed Values:` Choices from enum :class:`~.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
@@ -574,7 +573,7 @@ class CASClient:
             keyword, which refers to the default selected model in the Cellarium backend. |br|
             `Default:` ``"default"``
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
+            `Allowed Values:` Choices from enum :class:`~.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
@@ -626,7 +625,7 @@ class CASClient:
             keyword, which refers to the default selected model in the Cellarium backend. |br|
             `Default:` ``"default"``
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
+            `Allowed Values:` Choices from enum :class:`~.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
@@ -672,7 +671,7 @@ class CASClient:
             to annotate
         :param chunk_size: Size of chunks to split on
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
+            `Allowed Values:` Choices from enum :class:`~.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
@@ -741,7 +740,7 @@ class CASClient:
             to annotate
         :param chunk_size: Size of chunks to split on
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
+            `Allowed Values:` Choices from enum :class:`~.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
@@ -815,7 +814,7 @@ class CASClient:
             keyword, which refers to the default selected model in the Cellarium backend. |br|
             `Default:` ``"default"``
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
+            `Allowed Values:` Choices from enum :class:`~.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
@@ -873,7 +872,7 @@ class CASClient:
             keyword, which refers to the default selected model in the Cellarium backend. |br|
             `Default:` ``"default"``
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
+            `Allowed Values:` Choices from enum :class:`~.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
@@ -918,7 +917,7 @@ class CASClient:
             to annotate
         :param chunk_size: Size of chunks to split on
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
+            `Allowed Values:` Choices from enum :class:`~.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index

--- a/cellarium/cas/client.py
+++ b/cellarium/cas/client.py
@@ -36,9 +36,10 @@ FEEDBACK_TEMPLATE = pkgutil.get_data(__name__, "resources/feedback_template.html
 
 class CASClient:
     """
-    Service that is designed to communicate with the Cellarium Cloud Backend.
+    Client that is designed to communicate with the Cellarium Cloud Backend.
 
-    :param api_token: API token issued by the Cellarium team
+    :param api_token: API token issued by the Cellarium team.
+    :param api_url: URL of the Cellarium Cloud Backend. Should be left blank in most cases.
     :param num_attempts_per_chunk: Number of attempts the client should make to annotate each chunk. |br|
         `Default:` ``3``
     """
@@ -83,7 +84,7 @@ class CASClient:
         application_info = self.cas_api_service.get_application_info()
 
         self.model_objects_list = self.cas_api_service.get_model_list()
-        self.allowed_models_list = [x["model_name"] for x in self.model_objects_list]
+        self.__allowed_models_list = [x["model_name"] for x in self.model_objects_list]
         self._model_name_obj_map = {x["model_name"]: x for x in self.model_objects_list}
         self.default_model_name = [x["model_name"] for x in self.model_objects_list if x["is_default_model"]][0]
 
@@ -94,6 +95,13 @@ class CASClient:
         self._print(f"Authenticated in Cellarium Cloud v. {application_info['application_version']}")
 
         self._print_models(self.model_objects_list)
+
+    @property
+    def allowed_models_list(self):
+        """
+        List of models in Cellarium CAS that can be used to annotate.
+        """
+        return self.__allowed_models_list
 
     @staticmethod
     def _get_number_of_chunks(adata, chunk_size):
@@ -439,7 +447,7 @@ class CASClient:
 
         :param adata: :class:`anndata.AnnData` instance to annotate
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`cellarium.cas.constants.CountMatrixInput` |br|
+            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
@@ -503,7 +511,8 @@ class CASClient:
             keyword, which refers to the default selected model in the Cellarium backend. |br|
             `Default:` ``"default"``
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`cellarium.cas.constants.CountMatrixInput` |br|
+            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
+            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
@@ -565,7 +574,7 @@ class CASClient:
             keyword, which refers to the default selected model in the Cellarium backend. |br|
             `Default:` ``"default"``
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`cellarium.cas.constants.CountMatrixInput` |br|
+            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
@@ -617,7 +626,7 @@ class CASClient:
             keyword, which refers to the default selected model in the Cellarium backend. |br|
             `Default:` ``"default"``
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`cellarium.cas.constants.CountMatrixInput` |br|
+            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
@@ -663,7 +672,7 @@ class CASClient:
             to annotate
         :param chunk_size: Size of chunks to split on
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`cellarium.cas.constants.CountMatrixInput` |br|
+            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
@@ -732,7 +741,7 @@ class CASClient:
             to annotate
         :param chunk_size: Size of chunks to split on
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`cellarium.cas.constants.CountMatrixInput` |br|
+            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
@@ -806,7 +815,7 @@ class CASClient:
             keyword, which refers to the default selected model in the Cellarium backend. |br|
             `Default:` ``"default"``
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`cellarium.cas.constants.CountMatrixInput` |br|
+            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
@@ -864,7 +873,7 @@ class CASClient:
             keyword, which refers to the default selected model in the Cellarium backend. |br|
             `Default:` ``"default"``
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`cellarium.cas.constants.CountMatrixInput` |br|
+            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index
@@ -909,7 +918,7 @@ class CASClient:
             to annotate
         :param chunk_size: Size of chunks to split on
         :param count_matrix_input:  Where to obtain a feature expression count matrix from. |br|
-            `Allowed Values: Choices from enum :class:`cellarium.cas.constants.CountMatrixInput` |br|
+            `Allowed Values: Choices from enum :class:`constants.CountMatrixInput` |br|
             `Default:` ``"CountMatrixInput.X"``
         :param feature_ids_column_name: Column name where to obtain Ensembl feature ids. |br|
             `Allowed Values:` A value from ``adata.var.columns`` or ``"index"`` keyword, which refers to index

--- a/cellarium/cas/constants.py
+++ b/cellarium/cas/constants.py
@@ -3,7 +3,8 @@ from enum import Enum
 
 class HTTP:
     """
-    HTTP status codes constants
+    HTTP status codes constants.
+
     """
 
     STATUS_200_OK = 200
@@ -27,11 +28,21 @@ class HTTP:
 
 
 class CountMatrixInput(Enum):
+    """
+    Constants for the count matrix input type.
+
+    """
+
     X: str = "X"
     RAW_X: str = "raw.X"
 
 
 class Headers:
+    """
+    Header constants that are potentially sent to the CAS API.
+
+    """
+
     # The authorization header.
     authorization = "Authorization"
     # The client session id that is used to track a user's CAS client session.

--- a/cellarium/cas/visualization/__init__.py
+++ b/cellarium/cas/visualization/__init__.py
@@ -6,7 +6,7 @@ try:
 
     __all__ = ["CASCircularTreePlotUMAPDashApp", "find_and_kill_process"]
 except ImportError:
-    logging.debug(
+    logging.warn(
         """
 Visualization dependencies not installed.
 To install the Cellarium CAS Client with visualation dependencies, please run:

--- a/docs/source/automodules/client.rst
+++ b/docs/source/automodules/client.rst
@@ -3,4 +3,8 @@ Client
 
 .. automodule:: cellarium.cas.client
    :members:
-   :show-inheritance:
+
+.. autoclass:: cellarium.cas.constants.CountMatrixInput
+   :members:
+   :undoc-members:
+   :member-order: bysource

--- a/docs/source/automodules/visualization.rst
+++ b/docs/source/automodules/visualization.rst
@@ -1,6 +1,15 @@
 CAS Output Visualization
 ========================
 
-.. automodule:: cellarium.cas.visualization
+.. autoclass:: cellarium.cas.visualization.CASCircularTreePlotUMAPDashApp
    :members:
-   :show-inheritance:
+
+.. autoclass:: cellarium.cas.postprocessing.ontology_aware.CellOntologyScoresAggregationOp
+   :members:
+   :undoc-members:
+   :member-order: bysource
+   
+.. autoclass:: cellarium.cas.postprocessing.ontology_aware.CellOntologyScoresAggregationDomain
+   :members:
+   :undoc-members:
+   :member-order: bysource

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,8 +13,8 @@ from setuptools_git_versioning import get_tag
 project = "Cellarium CAS"
 copyright = f"{time.strftime('%Y')}, Cellarium AI"
 author = "Cellarium AI"
-version = get_tag()
-release = get_tag()
+version = get_tag() or "<no version>"
+release = get_tag() or "<no release>"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,6 +3,8 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 import time
+
+from sphinx.application import Sphinx
 from setuptools_git_versioning import get_tag
 
 # -- Project information -----------------------------------------------------
@@ -22,6 +24,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
     "sphinx_substitution_extensions",
 ]
 
@@ -39,6 +42,10 @@ rst_epilog = """
 
    <br />
 """
+
+intersphinx_mapping = {
+    "anndata": ("https://anndata.readthedocs.io/en/stable/", None),
+}
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,15 +2,17 @@
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-import os
+import time
 from setuptools_git_versioning import get_tag
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "Cellarium CAS"
-copyright = "2023, Cellarium AI"
+copyright = f"{time.strftime('%Y')}, Cellarium AI"
 author = "Cellarium AI"
+version = get_tag()
+release = get_tag()
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -20,10 +22,17 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
+    "sphinx_substitution_extensions",
 ]
 
-templates_path = ["_templates"]
-exclude_patterns = ["**/installation_template.rst"]
+# Provide substitutions for common values
+rst_prolog = f"""
+.. |project| replace:: {project}
+.. |copyright| replace:: {copyright}
+.. |author| replace:: {author}
+.. |version| replace:: {version}
+.. |release| replace:: {release}
+"""
 
 rst_epilog = """
 .. |br| raw:: html
@@ -35,28 +44,3 @@ rst_epilog = """
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "sphinx_rtd_theme"
-html_static_path = ["_static"]
-
-
-def substitute_installation_version():
-    """
-    Generate /modules/installation_.rst from /modules/installation.rst by substituting '|cas_version|' with a tagged
-    version of a library.
-    This step was necessary because the Sphinx builder couldn't replace the '|cas_version|' variable with a value
-    inside a code block.
-    """
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    cellarium_cas_version = get_tag()
-
-    with open(f"{dir_path}/modules/installation_template.rst", "r") as f:
-        content = f.read()
-
-    # Replace the placeholder with the version
-    content = content.replace("|cas_version|", cellarium_cas_version)
-
-    # Write the processed content to the actual .rst file
-    with open(f"{dir_path}/modules/installation.rst", "w") as f:
-        f.write(content)
-
-
-substitute_installation_version()

--- a/docs/source/modules/installation.rst
+++ b/docs/source/modules/installation.rst
@@ -11,6 +11,9 @@ The cellarium-cas package officially supports Python versions between 3.7 and 3.
 From github repository
 ++++++++++++++++++++++
 
-Install the latest alpha version using `pip` with a specified version::
+Install the latest alpha version using `pip` with a specified version:
 
-    pip install cellarium-cas==|cas_version|
+.. code-block:: bash
+   :substitutions:
+
+    pip install cellarium-cas==|version|

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,6 @@
 Pillow~=9.5
 Sphinx~=7.2
 sphinx_gallery~=0.14
-sphinx_rtd_theme~=1.3
+sphinx_rtd_theme~=2.0
+sphinx_substitution_extensions==2024.8.6
 setuptools-git-versioning==1.13.5

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,5 @@
 Pillow~=9.5
-Sphinx~=7.2
+Sphinx~=7.4
 sphinx_gallery~=0.14
 sphinx_rtd_theme~=2.0
 sphinx_substitution_extensions==2024.8.6

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,9 @@ commands =
     isort --line-length 120 --profile black tests cellarium
 
 [testenv:docs]
-deps = -rrequirements/docs.txt
+deps =
+    -rrequirements/docs.txt
+    -rrequirements/vis.txt
 changedir =
     {toxinidir}/docs
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ deps =
 changedir =
     {toxinidir}/docs
 commands =
-    make html
+    make html SPHINXOPTS="-W --keep-going -n"
  
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -17,13 +17,13 @@ ignore = E203, E501, W503
 
 [testenv]
 deps = -rrequirements/test.txt
+allowlist_externals = make
 commands =
     pytest tests/unit tests/integration \
         --cov-report term-missing \
         --cov-report html \
         --cov-report xml \
         {posargs}
-
 
 [testenv:unit]
 deps = -rrequirements/test.txt
@@ -61,6 +61,13 @@ skip_install = true
 commands = 
     black --line-length 120 cellarium tests
     isort --line-length 120 --profile black tests cellarium
+
+[testenv:docs]
+deps = -rrequirements/docs.txt
+changedir =
+    {toxinidir}/docs
+commands =
+    make html
  
 
 [gh-actions]


### PR DESCRIPTION
The PR does a few things:
- Adds a new tox environment called `docs` to build docs locally.  Run using:
```tox -e docs```
- Makes the doc builds fail if there is an issue with the doc builds (e.g. orphaned doc links, unclosed quotes, etc.)
- Adds a step to the unit test action to try to build the docs (will ensure docs can build safely)
- Added version to the docs
- Simplified version replacement
- Fixed a whole bunch of docs that were - as a result of doc build - failing the builds
- Note: docs will still be build using RTD's doc building