### PR TITLE
CAS-66 Don't show pre-release rel notes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,14 +6,20 @@ All notable changes to Cellarium CAS client will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
-<pre-version> - <pre-date>
---------------------------
 
-Changed
-~~~~~~~
-- Added ability to render documentation locally
-- PR tests will now fail when doc is invalid
-- Fixed bugs documentation navigation
+..
+  The text in this block is where pre-release changes should live.
+  On release, a commit should be created to copy the block just below with the new version number and date. 
+  Then a new block should be created here for the next version.
+
+  <pre-version> - <pre-date>
+  --------------------------
+
+  Changed
+  ~~~~~~~
+  - Added ability to render documentation locally
+  - PR tests will now fail when doc is invalid
+  - Fixed bugs documentation navigation
 
 1.4.12 - 2024-08-01
 -------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,7 +4,6 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 import time
 
-from sphinx.application import Sphinx
 from setuptools_git_versioning import get_tag
 
 # -- Project information -----------------------------------------------------

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -3,4 +3,4 @@ Sphinx~=7.4
 sphinx_gallery~=0.14
 sphinx_rtd_theme~=2.0
 sphinx_substitution_extensions==2024.8.6
-setuptools-git-versioning==1.13.5
+setuptools-git-versioning==2.0.0


### PR DESCRIPTION
Before we release and while new features are going in, we should keep the active rel notes up to date in a comment block. On release, we should copy the relnotes into a new version section and start a new comment.