### PR TITLE
Fix(vis): #114 Pin ScanPy and biopython dependencies

### DIFF
--- a/requirements/vis.txt
+++ b/requirements/vis.txt
@@ -1,5 +1,6 @@
-scanpy[leiden]>=1.9.0,<1.9.6
-biopython
+scanpy[leiden]>=1.9.0,<1.10.0; python_version < "3.12"
+scanpy[leiden]>=1.11.0,<1.12.0; python_version >= "3.12"
+biopython==1.85
 plotly
 dash==2.17.1
 dash-bootstrap-components==1.6.0


### PR DESCRIPTION
Update scanpy dependency because in python 3.12+ environments scanpy and anndata were incompatible. 