### PR TITLE
Add citation section to documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please visit the project's [ReadTheDocs page](https://cellarium-cas.readthedocs.
 # Citation
 If the Cellarium Cell Annotation Service (CAS) contributes to your research, please cite our preprint to help others discover the project. You can reference it as follows:
 
-> Williams, Stephen R., Grab, Fedor, Kamath, Govinda M., Ordabayev, Yerdos, Mellen, Jeff, Roelli, Patrick, Cibulskis, Kristian, Lehnert, Erik, Xie, Fen, Covarrubias, Miguel, Rahman, Nur-Taz, Tickle, Timothy, Erhan, Emre, Malfroy-Camine, Nicolas, Lydon, Kevin, Babadi, Mehrtash, and Delaney, Nigel F. 2025. *Accelerating scRNA-seq Analysis: Automated cell type annotation using representation learning and vector search.* bioRxiv. https://doi.org/10.1101/2025.10.06.680787
+> Stephen R Williams, Fedor Grab, Govinda M Kamath, Yerdos Ordabayev, Jeff Mellen, Patrick Roelli, Kristian Cibulskis, Erik Lehnert, Fen Xie, Miguel Covarrubias, Nur-Taz Rahman, Timothy Tickle, Emre Erhan, Nicolas Malfroy-Camine, Kevin Lydon, Mehrtash Babadi, Nigel F. Delaney. 2025. *Accelerating scRNA-seq Analysis: Automated cell type annotation using representation learning and vector search.* bioRxiv. https://doi.org/10.1101/2025.10.06.680787
 
 BibTeX users can cite CAS with:
 

--- a/README.md
+++ b/README.md
@@ -30,3 +30,21 @@ It is even easier to go through the quickstart tutorial on Google Colab. Remembe
 
 # Documentation
 Please visit the project's [ReadTheDocs page](https://cellarium-cas.readthedocs.io/) for additional documentation.
+
+# Citation
+If the Cellarium Cell Annotation Service (CAS) contributes to your research, please cite our preprint to help others discover the project. You can reference it as follows:
+
+> Williams, Stephen R., Grab, Fedor, Kamath, Govinda M., Ordabayev, Yerdos, Mellen, Jeff, Roelli, Patrick, Cibulskis, Kristian, Lehnert, Erik, Xie, Fen, Covarrubias, Miguel, Rahman, Nur-Taz, Tickle, Timothy, Erhan, Emre, Malfroy-Camine, Nicolas, Lydon, Kevin, Babadi, Mehrtash, and Delaney, Nigel F. 2025. *Accelerating scRNA-seq Analysis: Automated cell type annotation using representation learning and vector search.* bioRxiv. https://doi.org/10.1101/2025.10.06.680787
+
+BibTeX users can cite CAS with:
+
+```
+@article{cellarium_10x_cas,
+  author = {Williams, Stephen R. and Grab, Fedor and Kamath, Govinda M. and Ordabayev, Yerdos and Mellen, Jeff and Roelli, Patrick and Cibulskis, Kristian and Lehnert, Erik and Xie, Fen and Covarrubias, Miguel and Rahman, Nur-Taz and Tickle, Timothy and Erhan, Emre and Malfroy-Camine, Nicolas and Lydon, Kevin and Babadi, Mehrtash and Delaney, Nigel F.},
+  title = {Accelerating scRNA-seq Analysis: Automated cell type annotation using representation learning and vector search},
+  journal = {bioRxiv},
+  year = {2025},
+  doi = {10.1101/2025.10.06.680787},
+  url = {https://www.biorxiv.org/content/10.1101/2025.10.06.680787v1}
+}
+```

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -63,7 +63,7 @@ Citation
 
 If the Cellarium Cell Annotation Service (CAS) contributes to your research, please cite our preprint to help others discover the project. You can reference it as follows:
 
-Williams, Stephen R., Grab, Fedor, Kamath, Govinda M., Ordabayev, Yerdos, Mellen, Jeff, Roelli, Patrick, Cibulskis, Kristian, Lehnert, Erik, Xie, Fen, Covarrubias, Miguel, Rahman, Nur-Taz, Tickle, Timothy, Erhan, Emre, Malfroy-Camine, Nicolas, Lydon, Kevin, Babadi, Mehrtash, and Delaney, Nigel F. 2025. *Accelerating scRNA-seq Analysis: Automated cell type annotation using representation learning and vector search.* bioRxiv. https://doi.org/10.1101/2025.10.06.680787
+Stephen R Williams, Fedor Grab, Govinda M Kamath, Yerdos Ordabayev, Jeff Mellen, Patrick Roelli, Kristian Cibulskis, Erik Lehnert, Fen Xie, Miguel Covarrubias, Nur-Taz Rahman, Timothy Tickle, Emre Erhan, Nicolas Malfroy-Camine, Kevin Lydon, Mehrtash Babadi, Nigel F. Delaney. 2025. *Accelerating scRNA-seq Analysis: Automated cell type annotation using representation learning and vector search.* bioRxiv. https://doi.org/10.1101/2025.10.06.680787
 
 BibTeX users can cite CAS with:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,3 +57,24 @@ Related Projects
     * `Cellarium ML Library <https://cellarium-ai.github.io/cellarium-ml/index.html>`_
     * `Cellarium Cloud (Backend) <https://github.com/cellarium-ai/cellarium-cloud>`_
 
+
+Citation
+========
+
+If the Cellarium Cell Annotation Service (CAS) contributes to your research, please cite our preprint to help others discover the project. You can reference it as follows:
+
+Williams, Stephen R., Grab, Fedor, Kamath, Govinda M., Ordabayev, Yerdos, Mellen, Jeff, Roelli, Patrick, Cibulskis, Kristian, Lehnert, Erik, Xie, Fen, Covarrubias, Miguel, Rahman, Nur-Taz, Tickle, Timothy, Erhan, Emre, Malfroy-Camine, Nicolas, Lydon, Kevin, Babadi, Mehrtash, and Delaney, Nigel F. 2025. *Accelerating scRNA-seq Analysis: Automated cell type annotation using representation learning and vector search.* bioRxiv. https://doi.org/10.1101/2025.10.06.680787
+
+BibTeX users can cite CAS with:
+
+.. code-block:: text
+
+   @article{cellarium_10x_cas,
+     author = {Williams, Stephen R. and Grab, Fedor and Kamath, Govinda M. and Ordabayev, Yerdos and Mellen, Jeff and Roelli, Patrick and Cibulskis, Kristian and Lehnert, Erik and Xie, Fen and Covarrubias, Miguel and Rahman, Nur-Taz and Tickle, Timothy and Erhan, Emre and Malfroy-Camine, Nicolas and Lydon, Kevin and Babadi, Mehrtash and Delaney, Nigel F.},
+     title = {Accelerating scRNA-seq Analysis: Automated cell type annotation using representation learning and vector search},
+     journal = {bioRxiv},
+     year = {2025},
+     doi = {10.1101/2025.10.06.680787},
+     url = {https://www.biorxiv.org/content/10.1101/2025.10.06.680787v1}
+   }
+

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,5 @@
-pytest~=7.3
+pytest~=7.3; python_version < "3.10"
+pytest>=9.0.3; python_version >= "3.10"
 coverage~=4.5
 click~=8.0
 mockito>=1.5.0


### PR DESCRIPTION
## Summary
- add a citation section to the documentation landing page
- include the official bioRxiv reference and BibTeX entry for Cellarium CAS

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f258ddc858832698e5e4e5062ae257


Closes #121 